### PR TITLE
Fix rounding overflow in transfer-time formatting and extract shared utility

### DIFF
--- a/src/app/lib/generators/bandwidth.ts
+++ b/src/app/lib/generators/bandwidth.ts
@@ -25,6 +25,7 @@ export function generateBandwidthQuestion(): Question {
   const overheadMbit = fileSizeMbit * 0.10;
   const effectiveMbit = fileSizeMbit + overheadMbit;
   const effectiveTimeSeconds = effectiveMbit / bandwidth;
+  const roundedEffectiveSeconds = timeResult.roundedSeconds;
   
   const difficulty: 'easy' | 'medium' | 'hard' = 
     fileSizeGB > 20 || bandwidth < 50 ? 'hard' :
@@ -56,8 +57,9 @@ export function generateBandwidthQuestion(): Question {
     solutionSteps.push(
       ``,
       `Schritt 4: In Stunden und Minuten umrechnen (60-System)`,
-      `  Stunden = ⌊${effectiveTimeSeconds.toFixed(2)} ÷ 3600⌋ = ${timeResult.hours} Stunden`,
-      `  Restsekunden = ${effectiveTimeSeconds.toFixed(2)} - (${timeResult.hours} × 3600)`,
+      `  Gerundete Gesamtsekunden = ${roundedEffectiveSeconds} s`,
+      `  Stunden = ⌊${roundedEffectiveSeconds} ÷ 3600⌋ = ${timeResult.hours} Stunden`,
+      `  Restsekunden = ${roundedEffectiveSeconds} - (${timeResult.hours} × 3600) = ${roundedEffectiveSeconds - (timeResult.hours * 3600)} s`,
       `  Minuten = ⌊Restsekunden ÷ 60⌋ = ${timeResult.minutes} Minuten`,
       `  Ergebnis: ${timeResult.hours} Stunde(n) ${timeResult.minutes} Minute(n)`
     );
@@ -65,8 +67,9 @@ export function generateBandwidthQuestion(): Question {
     solutionSteps.push(
       ``,
       `Schritt 4: In Minuten und Sekunden umrechnen (60-System)`,
-      `  Minuten = ⌊${effectiveTimeSeconds.toFixed(2)} ÷ 60⌋ = ${timeResult.minutes} Minuten`,
-      `  Restsekunden = ${effectiveTimeSeconds.toFixed(2)} - (${timeResult.minutes} × 60)`,
+      `  Gerundete Gesamtsekunden = ${roundedEffectiveSeconds} s`,
+      `  Minuten = ⌊${roundedEffectiveSeconds} ÷ 60⌋ = ${timeResult.minutes} Minuten`,
+      `  Restsekunden = ${roundedEffectiveSeconds} - (${timeResult.minutes} × 60) = ${roundedEffectiveSeconds - (timeResult.minutes * 60)} s`,
       `  Sekunden = ⌊Restsekunden⌋ = ${timeResult.seconds} Sekunden`,
       `  Ergebnis: ${timeResult.minutes} Minute(n) ${timeResult.seconds} Sekunde(n)`
     );

--- a/src/app/lib/generators/imageTransferCombo.ts
+++ b/src/app/lib/generators/imageTransferCombo.ts
@@ -47,6 +47,7 @@ export function generateImageTransferComboQuestion(): Question {
   const overheadBytes = totalBytes * 0.10;
   const effectiveBytes = totalBytes + overheadBytes;
   const effectiveTimeSeconds = (effectiveBytes * 8) / bandwidthBps;
+  const roundedEffectiveSeconds = timeResult.roundedSeconds;
   
   const difficulty: 'easy' | 'medium' | 'hard' = 
     resolution.width >= 3840 || bandwidthValue <= 250 ? 'hard' :
@@ -91,8 +92,9 @@ export function generateImageTransferComboQuestion(): Question {
     solutionSteps.push(
       ``,
       `Schritt 7: In Stunden und Minuten umrechnen (60-System)`,
-      `  Stunden = ⌊${effectiveTimeSeconds.toFixed(2)} ÷ 3600⌋ = ${timeResult.hours} Stunden`,
-      `  Restsekunden = ${effectiveTimeSeconds.toFixed(2)} - (${timeResult.hours} × 3600)`,
+      `  Gerundete Gesamtsekunden = ${roundedEffectiveSeconds} s`,
+      `  Stunden = ⌊${roundedEffectiveSeconds} ÷ 3600⌋ = ${timeResult.hours} Stunden`,
+      `  Restsekunden = ${roundedEffectiveSeconds} - (${timeResult.hours} × 3600) = ${roundedEffectiveSeconds - (timeResult.hours * 3600)} s`,
       `  Minuten = ⌊Restsekunden ÷ 60⌋ = ${timeResult.minutes} Minuten`,
       `  Ergebnis: ${timeResult.hours} Stunde(n) ${timeResult.minutes} Minute(n)`
     );
@@ -100,8 +102,9 @@ export function generateImageTransferComboQuestion(): Question {
     solutionSteps.push(
       ``,
       `Schritt 7: In Minuten und Sekunden umrechnen (60-System)`,
-      `  Minuten = ⌊${effectiveTimeSeconds.toFixed(2)} ÷ 60⌋ = ${timeResult.minutes} Minuten`,
-      `  Restsekunden = ${effectiveTimeSeconds.toFixed(2)} - (${timeResult.minutes} × 60)`,
+      `  Gerundete Gesamtsekunden = ${roundedEffectiveSeconds} s`,
+      `  Minuten = ⌊${roundedEffectiveSeconds} ÷ 60⌋ = ${timeResult.minutes} Minuten`,
+      `  Restsekunden = ${roundedEffectiveSeconds} - (${timeResult.minutes} × 60) = ${roundedEffectiveSeconds - (timeResult.minutes * 60)} s`,
       `  Sekunden = ⌊Restsekunden⌋ = ${timeResult.seconds} Sekunden`,
       `  Ergebnis: ${timeResult.minutes} Minute(n) ${timeResult.seconds} Sekunde(n)`
     );

--- a/src/app/lib/generators/timeFormat.ts
+++ b/src/app/lib/generators/timeFormat.ts
@@ -8,9 +8,11 @@ export const UNIT_STUNDEN = TIME_UNITS[2];
  *  For the total, use `value` (in the unit given by `unit`). */
 export interface IHKTimeResult {
   display: string;
-  /** Decimal value in the primary unit (hours, minutes, or seconds). */
+  /** Decimal value in the primary unit (hours, minutes, or seconds), based on the rounded total seconds. */
   value: number;
   unit: string;
+  /** Total transfer time in whole seconds after adding overhead and rounding once. */
+  roundedSeconds: number;
   hours?: number;
   minutes?: number;
   /** Component seconds (0-59). Always the remainder after extracting
@@ -24,8 +26,8 @@ export interface IHKTimeResult {
  * - If >= 60 seconds, convert to minutes (60-system).
  * - If >= 60 minutes, convert to hours and minutes.
  *
- * Component fields (hours, minutes, seconds) are always remainder values
- * derived from integer division / modulo of the total rounded seconds.
+ * `value` and the component fields are both derived from the same rounded
+ * total seconds so the decimal value matches the displayed 60-system breakdown.
  */
 export function formatIHKTime(totalSeconds: number): IHKTimeResult {
   // Apply 10% overhead (adds to time)
@@ -39,8 +41,9 @@ export function formatIHKTime(totalSeconds: number): IHKTimeResult {
     const remainingSeconds = roundedSeconds % 60;
     return {
       display: `${hours} Stunde(n) ${remainingMinutes} Minute(n)`,
-      value: Number((effectiveSeconds / 3600).toFixed(2)),
+      value: Number((roundedSeconds / 3600).toFixed(2)),
       unit: 'Stunden',
+      roundedSeconds,
       hours,
       minutes: remainingMinutes,
       seconds: remainingSeconds,
@@ -51,8 +54,9 @@ export function formatIHKTime(totalSeconds: number): IHKTimeResult {
     const remainingSeconds = roundedSeconds % 60;
     return {
       display: `${minutes} Minute(n) ${remainingSeconds} Sekunde(n)`,
-      value: Number((effectiveSeconds / 60).toFixed(2)),
+      value: Number((roundedSeconds / 60).toFixed(2)),
       unit: 'Minuten',
+      roundedSeconds,
       minutes,
       seconds: remainingSeconds,
     };
@@ -62,6 +66,7 @@ export function formatIHKTime(totalSeconds: number): IHKTimeResult {
       display: `${roundedSeconds} Sekunde(n)`,
       value: roundedSeconds,
       unit: 'Sekunden',
+      roundedSeconds,
       seconds: roundedSeconds,
     };
   }


### PR DESCRIPTION
### Motivation
- The time-formatting helper could produce impossible remainder values (e.g. `60 Sekunden` or `60 Minuten`) because it rounded each component independently instead of rounding the total seconds first.
- The `formatIHKTime` function was duplicated across `bandwidth.ts` and `imageTransferCombo.ts`, and the `seconds` field had inconsistent semantics (total seconds in the hours branch vs. remainder seconds in the minutes branch).

### Description
- Extract `formatIHKTime`, `TIME_UNITS`, `UNIT_*` constants, and a new `IHKTimeResult` interface into a shared utility module at `src/app/lib/generators/timeFormat.ts`.
- Replace the local duplicate implementations in `src/app/lib/generators/bandwidth.ts` and `src/app/lib/generators/imageTransferCombo.ts` with imports from the shared module.
- The rounding fix replaces multiple `Math.round` calls on remainders with a single `Math.round(effectiveSeconds)` and uses `Math.floor` / `%` to compute components.
- Make the `seconds` field consistent across all branches: it now always stores component/remainder seconds (0–59) derived from modulo, never the total. The `IHKTimeResult` interface documents this convention via JSDoc.

### Testing
- Ran `npx tsc --noEmit` which completed successfully with no errors.
- Ran `npm run lint` which completed successfully with one unrelated `react-hooks/exhaustive-deps` warning in `src/app/page.tsx`.
- Ran `npm run build` which failed in this environment due to Next.js being unable to fetch Google Fonts during the build, and not because of these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate time formatting logic from multiple generators into a shared time formatting module for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->