### PR TITLE
Harden binary/hex answer validation

### DIFF
--- a/src/app/lib/__tests__/answerValidation.test.ts
+++ b/src/app/lib/__tests__/answerValidation.test.ts
@@ -112,6 +112,8 @@ describe('answer validation helpers', () => {
       };
       expect(validateQuestionAnswers(highBitBinaryQuestion, { binary: '11001000' })).toBe(true);
       expect(validateQuestionAnswers(highBitBinaryQuestion, { binary: '11001001' })).toBe(false);
+      expect(validateQuestionAnswers(highBitBinaryQuestion, { binary: '011001000' })).toBe(false);
+      expect(validateQuestionAnswers(highBitBinaryQuestion, { binary: '11001000abc' })).toBe(false);
     });
 
     it('enforces leading zeros for all-zero binary', () => {

--- a/src/app/lib/__tests__/answerValidation.test.ts
+++ b/src/app/lib/__tests__/answerValidation.test.ts
@@ -98,7 +98,7 @@ describe('answer validation helpers', () => {
       expect(validateQuestionAnswers(binaryQuestion, { binary: '11000' })).toBe(false);
     });
 
-    it('rejects wrong binary answer of same numeric value', () => {
+    it('rejects binary answer with wrong bit-width but same numeric value', () => {
       expect(validateQuestionAnswers(binaryQuestion, { binary: '0011000' })).toBe(false);
     });
 
@@ -202,6 +202,70 @@ describe('answer validation helpers', () => {
       expect(validateQuestionAnswers(hexWithLetter, { hex: '0xAF' })).toBe(true);
       expect(validateQuestionAnswers(hexWithLetter, { hex: '0xaf' })).toBe(true);
       expect(validateQuestionAnswers(hexWithLetter, { hex: 'AB' })).toBe(false);
+    });
+
+    it('rejects bare 0x prefix with no value', () => {
+      expect(validateQuestionAnswers(hexQuestion, { hex: '0x' })).toBe(false);
+    });
+  });
+
+  describe('structured path for binary and hex', () => {
+    it('validates binary and hex through answerInputs', () => {
+      expect(
+        validateStructuredAnswer(
+          [{ valueKey: 'binary' }, { valueKey: 'hex' }],
+          { binary: '00011000', hex: '18' },
+          { binary: '00011000', hex: '0x18' }
+        )
+      ).toBe(true);
+    });
+
+    it('rejects binary with missing leading zeros via structured path', () => {
+      expect(
+        validateStructuredAnswer(
+          [{ valueKey: 'binary' }],
+          { binary: '00011000' },
+          { binary: '11000' }
+        )
+      ).toBe(false);
+    });
+
+    it('rejects wrong hex via structured path', () => {
+      expect(
+        validateStructuredAnswer(
+          [{ valueKey: 'hex' }],
+          { hex: '18' },
+          { hex: '1B' }
+        )
+      ).toBe(false);
+    });
+
+    it('accepts hex 0x prefix via structured path', () => {
+      expect(
+        validateStructuredAnswer(
+          [{ valueKey: 'hex' }],
+          { hex: 'AF' },
+          { hex: '0xaf' }
+        )
+      ).toBe(true);
+    });
+
+    it('validates binary and hex in leftover-keys structured path', () => {
+      expect(
+        validateStructuredAnswer(
+          [{ valueKey: 'other' }],
+          { other: 42, binary: '00011000', hex: '18' },
+          { other: '42', binary: '00011000', hex: '0x18' }
+        )
+      ).toBe(true);
+
+      expect(
+        validateStructuredAnswer(
+          [{ valueKey: 'other' }],
+          { other: 42, binary: '00011000', hex: '18' },
+          { other: '42', binary: '11000', hex: '0x18' }
+        )
+      ).toBe(false);
     });
   });
 

--- a/src/app/lib/__tests__/answerValidation.test.ts
+++ b/src/app/lib/__tests__/answerValidation.test.ts
@@ -167,14 +167,29 @@ describe('answer validation helpers', () => {
       expect(validateQuestionAnswers(zeroPaddedHexQuestion, { hex: '0xE' })).toBe(false);
     });
 
-    it('accepts hex answer with leading zeros and 0x prefix', () => {
+    it('accepts numeric equivalents for zero-padded hex answers', () => {
       const hexWithLeadingZeros: Question = {
         ...hexQuestion,
         expectedAnswers: { hex: '001' },
       };
       expect(validateQuestionAnswers(hexWithLeadingZeros, { hex: '001' })).toBe(true);
       expect(validateQuestionAnswers(hexWithLeadingZeros, { hex: '0x001' })).toBe(true);
-      expect(validateQuestionAnswers(hexWithLeadingZeros, { hex: '1' })).toBe(false);
+      expect(validateQuestionAnswers(hexWithLeadingZeros, { hex: '1' })).toBe(true);
+      expect(validateQuestionAnswers(hexWithLeadingZeros, { hex: '0x1' })).toBe(true);
+      expect(validateQuestionAnswers(hexWithLeadingZeros, { hex: '2' })).toBe(false);
+    });
+
+    it('accepts shorthand for digit-only zero-padded hex answers', () => {
+      const digitOnlyZeroPadded: Question = {
+        ...hexQuestion,
+        expectedAnswers: { hex: '018' },
+        solutionSteps: ['0x018'],
+      };
+      expect(validateQuestionAnswers(digitOnlyZeroPadded, { hex: '018' })).toBe(true);
+      expect(validateQuestionAnswers(digitOnlyZeroPadded, { hex: '0x018' })).toBe(true);
+      expect(validateQuestionAnswers(digitOnlyZeroPadded, { hex: '18' })).toBe(true);
+      expect(validateQuestionAnswers(digitOnlyZeroPadded, { hex: '0x18' })).toBe(true);
+      expect(validateQuestionAnswers(digitOnlyZeroPadded, { hex: '0x19' })).toBe(false);
     });
 
     it('handles hex answers with letters case-insensitively', () => {

--- a/src/app/lib/__tests__/answerValidation.test.ts
+++ b/src/app/lib/__tests__/answerValidation.test.ts
@@ -78,4 +78,109 @@ describe('answer validation helpers', () => {
       )
     ).toBe(false);
   });
+
+  describe('binary answers with leading zeros', () => {
+    const binaryQuestion: Question = {
+      id: 'binary-1',
+      theme: 'Zahlensysteme',
+      module: 'binary',
+      questionText: 'Wandle die Dezimalzahl 24 in eine 8-Bit-Binärzahl um.',
+      expectedAnswers: { binary: '00011000' },
+      solutionSteps: ['00011000'],
+      difficulty: 'easy',
+    };
+
+    it('accepts the correct 8-bit binary answer', () => {
+      expect(validateQuestionAnswers(binaryQuestion, { binary: '00011000' })).toBe(true);
+    });
+
+    it('rejects binary answer without leading zeros', () => {
+      expect(validateQuestionAnswers(binaryQuestion, { binary: '11000' })).toBe(false);
+    });
+
+    it('rejects wrong binary answer of same numeric value', () => {
+      expect(validateQuestionAnswers(binaryQuestion, { binary: '0011000' })).toBe(false);
+    });
+
+    it('enforces leading zeros for all-zero binary', () => {
+      const allZeros: Question = {
+        ...binaryQuestion,
+        expectedAnswers: { binary: '00000000' },
+      };
+      expect(validateQuestionAnswers(allZeros, { binary: '00000000' })).toBe(true);
+      expect(validateQuestionAnswers(allZeros, { binary: '0' })).toBe(false);
+      expect(validateQuestionAnswers(allZeros, { binary: '0000000' })).toBe(false);
+    });
+  });
+
+  describe('hex answers with 0x prefix', () => {
+    const hexQuestion: Question = {
+      id: 'hex-1',
+      theme: 'Zahlensysteme',
+      module: 'hexBinary',
+      questionText: 'Wandle die Binärzahl 00011000 in eine Hexadezimalzahl um.',
+      expectedAnswers: { hex: '18' },
+      solutionSteps: ['0x18'],
+      difficulty: 'easy',
+    };
+
+    it('accepts plain hex answer', () => {
+      expect(validateQuestionAnswers(hexQuestion, { hex: '18' })).toBe(true);
+    });
+
+    it('accepts hex answer with 0x prefix', () => {
+      expect(validateQuestionAnswers(hexQuestion, { hex: '0x18' })).toBe(true);
+    });
+
+    it('accepts hex answer with 0X prefix (uppercase)', () => {
+      expect(validateQuestionAnswers(hexQuestion, { hex: '0X18' })).toBe(true);
+    });
+
+    it('rejects wrong hex answer', () => {
+      expect(validateQuestionAnswers(hexQuestion, { hex: '1B' })).toBe(false);
+    });
+
+    it('handles hex answers with letters case-insensitively', () => {
+      const hexWithLetter: Question = {
+        ...hexQuestion,
+        expectedAnswers: { hex: 'AF' },
+      };
+      expect(validateQuestionAnswers(hexWithLetter, { hex: 'AF' })).toBe(true);
+      expect(validateQuestionAnswers(hexWithLetter, { hex: 'af' })).toBe(true);
+      expect(validateQuestionAnswers(hexWithLetter, { hex: '0xAF' })).toBe(true);
+      expect(validateQuestionAnswers(hexWithLetter, { hex: '0xaf' })).toBe(true);
+      expect(validateQuestionAnswers(hexWithLetter, { hex: 'AB' })).toBe(false);
+    });
+  });
+
+  describe('regular numeric answers are unaffected', () => {
+    it('still accepts numeric answers within 5% tolerance', () => {
+      const question: Question = {
+        id: 'bandwidth-1',
+        theme: 'Test',
+        module: 'bandwidth',
+        questionText: 'How long?',
+        expectedAnswers: { result: 100 },
+        solutionSteps: ['100'],
+        difficulty: 'medium',
+      };
+      expect(validateQuestionAnswers(question, { result: '100' })).toBe(true);
+      expect(validateQuestionAnswers(question, { result: '102' })).toBe(true);
+      expect(validateQuestionAnswers(question, { result: '110' })).toBe(false);
+    });
+
+    it('still handles decimal comma', () => {
+      const question: Question = {
+        id: 'calc-1',
+        theme: 'Test',
+        module: 'math',
+        questionText: 'Calculate',
+        expectedAnswers: { result: 4.5 },
+        solutionSteps: ['4.5'],
+        difficulty: 'easy',
+      };
+      expect(validateQuestionAnswers(question, { result: '4,5' })).toBe(true);
+      expect(validateQuestionAnswers(question, { result: '4.5' })).toBe(true);
+    });
+  });
 });

--- a/src/app/lib/__tests__/answerValidation.test.ts
+++ b/src/app/lib/__tests__/answerValidation.test.ts
@@ -102,6 +102,18 @@ describe('answer validation helpers', () => {
       expect(validateQuestionAnswers(binaryQuestion, { binary: '0011000' })).toBe(false);
     });
 
+    it('rejects off-by-one answers for 8-bit binary values starting with 1', () => {
+      const highBitBinaryQuestion: Question = {
+        ...binaryQuestion,
+        id: 'binary-2',
+        questionText: 'Wandle die Dezimalzahl 200 in eine 8-Bit-Binärzahl um.',
+        expectedAnswers: { binary: '11001000' },
+        solutionSteps: ['11001000'],
+      };
+      expect(validateQuestionAnswers(highBitBinaryQuestion, { binary: '11001000' })).toBe(true);
+      expect(validateQuestionAnswers(highBitBinaryQuestion, { binary: '11001001' })).toBe(false);
+    });
+
     it('enforces leading zeros for all-zero binary', () => {
       const allZeros: Question = {
         ...binaryQuestion,
@@ -138,6 +150,29 @@ describe('answer validation helpers', () => {
 
     it('rejects wrong hex answer', () => {
       expect(validateQuestionAnswers(hexQuestion, { hex: '1B' })).toBe(false);
+    });
+
+    it('accepts 0x-prefixed shorthand for zero-padded expected hex answers', () => {
+      const zeroPaddedHexQuestion: Question = {
+        ...hexQuestion,
+        expectedAnswers: { hex: '00F' },
+        solutionSteps: ['0x00F'],
+      };
+      expect(validateQuestionAnswers(zeroPaddedHexQuestion, { hex: '00F' })).toBe(true);
+      expect(validateQuestionAnswers(zeroPaddedHexQuestion, { hex: '00f' })).toBe(true);
+      expect(validateQuestionAnswers(zeroPaddedHexQuestion, { hex: '0xF' })).toBe(true);
+      expect(validateQuestionAnswers(zeroPaddedHexQuestion, { hex: '0xf' })).toBe(true);
+      expect(validateQuestionAnswers(zeroPaddedHexQuestion, { hex: '0xE' })).toBe(false);
+    });
+
+    it('accepts hex answer with leading zeros and 0x prefix', () => {
+      const hexWithLeadingZeros: Question = {
+        ...hexQuestion,
+        expectedAnswers: { hex: '001' },
+      };
+      expect(validateQuestionAnswers(hexWithLeadingZeros, { hex: '001' })).toBe(true);
+      expect(validateQuestionAnswers(hexWithLeadingZeros, { hex: '0x001' })).toBe(true);
+      expect(validateQuestionAnswers(hexWithLeadingZeros, { hex: '1' })).toBe(false);
     });
 
     it('handles hex answers with letters case-insensitively', () => {

--- a/src/app/lib/answerValidation.ts
+++ b/src/app/lib/answerValidation.ts
@@ -54,6 +54,11 @@ const BASE_FOR_KEY: Record<string, number> = {
   hex: 16,
 };
 
+const VALID_BASE_PATTERN: Record<number, RegExp> = {
+  2: /^[01]+$/,
+  16: /^[0-9a-f]+$/,
+};
+
 /**
  * Detect the conversion map that applies for the given unit options.
  * Returns null when no conversion-aware check is needed.
@@ -117,6 +122,8 @@ export function validateStructuredAnswer(
 
     if (NON_DECIMAL_KEYS.has(cfg.valueKey)) {
       const base = BASE_FOR_KEY[cfg.valueKey];
+      if (!VALID_BASE_PATTERN[base].test(userAnswer)) return false;
+      if (cfg.valueKey === 'binary' && userAnswer.length !== expectedStr.length) return false;
       const userVal = parseInt(userAnswer, base);
       const expectedVal = parseInt(expectedStr, base);
       if (isNaN(userVal) || isNaN(expectedVal) || userVal !== expectedVal) return false;
@@ -182,6 +189,8 @@ export function validateStructuredAnswer(
 
     if (NON_DECIMAL_KEYS.has(key)) {
       const base = BASE_FOR_KEY[key];
+      if (!VALID_BASE_PATTERN[base].test(userAnswer)) return false;
+      if (key === 'binary' && userAnswer.length !== expectedStr.length) return false;
       const userVal = parseInt(userAnswer, base);
       const expectedVal = parseInt(expectedStr, base);
       if (isNaN(userVal) || isNaN(expectedVal) || userVal !== expectedVal) return false;
@@ -236,6 +245,8 @@ export function validateQuestionAnswers(
 
     if (NON_DECIMAL_KEYS.has(key)) {
       const base = BASE_FOR_KEY[key];
+      if (!VALID_BASE_PATTERN[base].test(userAnswer)) return false;
+      if (key === 'binary' && userAnswer.length !== expectedStr.length) return false;
       const userVal = parseInt(userAnswer, base);
       const expectedVal = parseInt(expectedStr, base);
       if (isNaN(userVal) || isNaN(expectedVal) || userVal !== expectedVal) return false;

--- a/src/app/lib/answerValidation.ts
+++ b/src/app/lib/answerValidation.ts
@@ -27,26 +27,6 @@ export function parseLocaleFloat(raw?: string | null): number {
   return parseFloat(raw.replace(',', '.'));
 }
 
-/**
- * Returns true when the string has significant leading zeros (e.g. "00011000").
- * Such values must be compared as strings, not numbers, because parseFloat
- * strips leading zeros and would incorrectly match "11000" against "00011000".
- */
-function hasSignificantLeadingZeros(s: string): boolean {
-  return /^0[0-9]+$/.test(s);
-}
-
-/**
- * Normalise a hex-style user answer by stripping an optional "0x" prefix.
- */
-function normalizeHexAnswer(s: string): string {
-  return s.replace(/^0x/i, '');
-}
-
-/**
- * Keys whose values must never be compared with decimal tolerance.
- * Binary and hex answers are exact-position or base-aware comparisons.
- */
 const NON_DECIMAL_KEYS = new Set(['binary', 'hex']);
 
 const BASE_FOR_KEY: Record<string, number> = {
@@ -58,6 +38,55 @@ const VALID_BASE_PATTERN: Record<number, RegExp> = {
   2: /^[01]+$/,
   16: /^[0-9a-f]+$/,
 };
+
+/**
+ * Normalise a hex-style user answer by stripping an optional "0x" prefix.
+ */
+function normalizeHexAnswer(s: string): string {
+  return s.replace(/^0x/i, '');
+}
+
+/**
+ * Returns true when the string is a binary value with significant leading zeros
+ * (e.g. "00011000"). Such values must be compared as fixed-width strings because
+ * numeric parsing strips leading zeros and would incorrectly match "11000"
+ * against "00011000".
+ *
+ * Scoped to binary-only patterns so that hex values like "018" (zero-padded
+ * digits from the hex generator) can still be compared numerically via parseInt.
+ */
+function hasBinaryLeadingZeros(s: string): boolean {
+  return /^0[01]+$/.test(s);
+}
+
+/**
+ * Validate a non-decimal (binary or hex) answer field.
+ * Returns true when the answer is acceptable, false to reject.
+ */
+function validateNonDecimalKey(
+  key: string,
+  rawUserAnswer: string,
+  expectedStr: string,
+): boolean | undefined {
+  if (!NON_DECIMAL_KEYS.has(key)) return undefined;
+
+  let userAnswer = rawUserAnswer;
+  if (key === 'hex') {
+    userAnswer = normalizeHexAnswer(userAnswer);
+  }
+
+  if (key === 'binary' && hasBinaryLeadingZeros(expectedStr)) {
+    return userAnswer === expectedStr;
+  }
+
+  const base = BASE_FOR_KEY[key];
+  if (!VALID_BASE_PATTERN[base].test(userAnswer)) return false;
+  if (key === 'binary' && userAnswer.length !== expectedStr.length) return false;
+
+  const userVal = parseInt(userAnswer, base);
+  const expectedVal = parseInt(expectedStr, base);
+  return !isNaN(userVal) && !isNaN(expectedVal) && userVal === expectedVal;
+}
 
 /**
  * Detect the conversion map that applies for the given unit options.
@@ -108,25 +137,12 @@ export function validateStructuredAnswer(
       continue;
     }
 
-    let userAnswer = (answers[cfg.valueKey] ?? '').trim().toLowerCase();
+    const userAnswer = (answers[cfg.valueKey] ?? '').trim().toLowerCase();
     const expectedStr = String(expected[cfg.valueKey]).toLowerCase();
 
-    if (cfg.valueKey === 'hex') {
-      userAnswer = normalizeHexAnswer(userAnswer);
-    }
-
-    if (hasSignificantLeadingZeros(expectedStr)) {
-      if (userAnswer !== expectedStr) return false;
-      continue;
-    }
-
-    if (NON_DECIMAL_KEYS.has(cfg.valueKey)) {
-      const base = BASE_FOR_KEY[cfg.valueKey];
-      if (!VALID_BASE_PATTERN[base].test(userAnswer)) return false;
-      if (cfg.valueKey === 'binary' && userAnswer.length !== expectedStr.length) return false;
-      const userVal = parseInt(userAnswer, base);
-      const expectedVal = parseInt(expectedStr, base);
-      if (isNaN(userVal) || isNaN(expectedVal) || userVal !== expectedVal) return false;
+    const nonDecimalResult = validateNonDecimalKey(cfg.valueKey, userAnswer, expectedStr);
+    if (nonDecimalResult !== undefined) {
+      if (!nonDecimalResult) return false;
       continue;
     }
 
@@ -175,25 +191,12 @@ export function validateStructuredAnswer(
       continue;
     }
 
-    let userAnswer = (answers[key] ?? '').trim().toLowerCase();
+    const userAnswer = (answers[key] ?? '').trim().toLowerCase();
     const expectedStr = String(exp).toLowerCase();
 
-    if (key === 'hex') {
-      userAnswer = normalizeHexAnswer(userAnswer);
-    }
-
-    if (hasSignificantLeadingZeros(expectedStr)) {
-      if (userAnswer !== expectedStr) return false;
-      continue;
-    }
-
-    if (NON_DECIMAL_KEYS.has(key)) {
-      const base = BASE_FOR_KEY[key];
-      if (!VALID_BASE_PATTERN[base].test(userAnswer)) return false;
-      if (key === 'binary' && userAnswer.length !== expectedStr.length) return false;
-      const userVal = parseInt(userAnswer, base);
-      const expectedVal = parseInt(expectedStr, base);
-      if (isNaN(userVal) || isNaN(expectedVal) || userVal !== expectedVal) return false;
+    const nonDecimalResult = validateNonDecimalKey(key, userAnswer, expectedStr);
+    if (nonDecimalResult !== undefined) {
+      if (!nonDecimalResult) return false;
       continue;
     }
 
@@ -231,25 +234,12 @@ export function validateQuestionAnswers(
   for (const [key, expected] of Object.entries(question.expectedAnswers)) {
     if (key === 'unit') continue;
 
-    let userAnswer = (answers[key] ?? '').trim().toLowerCase();
+    const userAnswer = (answers[key] ?? '').trim().toLowerCase();
     const expectedStr = String(expected).toLowerCase();
 
-    if (key === 'hex') {
-      userAnswer = normalizeHexAnswer(userAnswer);
-    }
-
-    if (hasSignificantLeadingZeros(expectedStr)) {
-      if (userAnswer !== expectedStr) return false;
-      continue;
-    }
-
-    if (NON_DECIMAL_KEYS.has(key)) {
-      const base = BASE_FOR_KEY[key];
-      if (!VALID_BASE_PATTERN[base].test(userAnswer)) return false;
-      if (key === 'binary' && userAnswer.length !== expectedStr.length) return false;
-      const userVal = parseInt(userAnswer, base);
-      const expectedVal = parseInt(expectedStr, base);
-      if (isNaN(userVal) || isNaN(expectedVal) || userVal !== expectedVal) return false;
+    const nonDecimalResult = validateNonDecimalKey(key, userAnswer, expectedStr);
+    if (nonDecimalResult !== undefined) {
+      if (!nonDecimalResult) return false;
       continue;
     }
 

--- a/src/app/lib/answerValidation.ts
+++ b/src/app/lib/answerValidation.ts
@@ -27,7 +27,7 @@ export function parseLocaleFloat(raw?: string | null): number {
   return parseFloat(raw.replace(',', '.'));
 }
 
-const NON_DECIMAL_KEYS = new Set(['binary', 'hex']);
+const RADIX_KEYS = new Set(['binary', 'hex']);
 
 const BASE_FOR_KEY: Record<string, number> = {
   binary: 2,
@@ -51,9 +51,6 @@ function normalizeHexAnswer(s: string): string {
  * (e.g. "00011000"). Such values must be compared as fixed-width strings because
  * numeric parsing strips leading zeros and would incorrectly match "11000"
  * against "00011000".
- *
- * Scoped to binary-only patterns so that hex values like "018" (zero-padded
- * digits from the hex generator) can still be compared numerically via parseInt.
  */
 function hasBinaryLeadingZeros(s: string): boolean {
   return /^0[01]+$/.test(s);
@@ -68,7 +65,9 @@ function validateNonDecimalKey(
   rawUserAnswer: string,
   expectedStr: string,
 ): boolean | undefined {
-  if (!NON_DECIMAL_KEYS.has(key)) return undefined;
+  if (!RADIX_KEYS.has(key)) return undefined;
+
+  // Note: "0b" prefix is intentionally not supported for binary; only bare digit strings are accepted.
 
   let userAnswer = rawUserAnswer;
   if (key === 'hex') {
@@ -76,6 +75,7 @@ function validateNonDecimalKey(
   }
 
   if (key === 'binary' && hasBinaryLeadingZeros(expectedStr)) {
+    if (!VALID_BASE_PATTERN[2].test(userAnswer)) return false;
     return userAnswer === expectedStr;
   }
 

--- a/src/app/lib/answerValidation.ts
+++ b/src/app/lib/answerValidation.ts
@@ -58,7 +58,8 @@ function hasBinaryLeadingZeros(s: string): boolean {
 
 /**
  * Validate a non-decimal (binary or hex) answer field.
- * Returns true when the answer is acceptable, false to reject.
+ * Returns true when the answer is acceptable, false to reject, and
+ * undefined when `key` is not a supported radix key.
  */
 function validateNonDecimalKey(
   key: string,

--- a/src/app/lib/answerValidation.ts
+++ b/src/app/lib/answerValidation.ts
@@ -44,6 +44,17 @@ function normalizeHexAnswer(s: string): string {
 }
 
 /**
+ * Keys whose values must never be compared with decimal tolerance.
+ * Binary and hex answers are exact-position or base-aware comparisons.
+ */
+const NON_DECIMAL_KEYS = new Set(['binary', 'hex']);
+
+const BASE_FOR_KEY: Record<string, number> = {
+  binary: 2,
+  hex: 16,
+};
+
+/**
  * Detect the conversion map that applies for the given unit options.
  * Returns null when no conversion-aware check is needed.
  */
@@ -104,6 +115,14 @@ export function validateStructuredAnswer(
       continue;
     }
 
+    if (NON_DECIMAL_KEYS.has(cfg.valueKey)) {
+      const base = BASE_FOR_KEY[cfg.valueKey];
+      const userVal = parseInt(userAnswer, base);
+      const expectedVal = parseInt(expectedStr, base);
+      if (isNaN(userVal) || isNaN(expectedVal) || userVal !== expectedVal) return false;
+      continue;
+    }
+
     const userNum = parseLocaleFloat(userAnswer);
     const expectedNum = parseLocaleFloat(expectedStr);
     const convMap = detectConversionMap(cfg.unitOptions ?? []);
@@ -161,6 +180,14 @@ export function validateStructuredAnswer(
       continue;
     }
 
+    if (NON_DECIMAL_KEYS.has(key)) {
+      const base = BASE_FOR_KEY[key];
+      const userVal = parseInt(userAnswer, base);
+      const expectedVal = parseInt(expectedStr, base);
+      if (isNaN(userVal) || isNaN(expectedVal) || userVal !== expectedVal) return false;
+      continue;
+    }
+
     const userNum = parseLocaleFloat(userAnswer);
     const expectedNum = parseLocaleFloat(expectedStr);
     if (!isNaN(userNum) && !isNaN(expectedNum)) {
@@ -204,6 +231,14 @@ export function validateQuestionAnswers(
 
     if (hasSignificantLeadingZeros(expectedStr)) {
       if (userAnswer !== expectedStr) return false;
+      continue;
+    }
+
+    if (NON_DECIMAL_KEYS.has(key)) {
+      const base = BASE_FOR_KEY[key];
+      const userVal = parseInt(userAnswer, base);
+      const expectedVal = parseInt(expectedStr, base);
+      if (isNaN(userVal) || isNaN(expectedVal) || userVal !== expectedVal) return false;
       continue;
     }
 

--- a/src/app/lib/answerValidation.ts
+++ b/src/app/lib/answerValidation.ts
@@ -27,12 +27,12 @@ export function parseLocaleFloat(raw?: string | null): number {
   return parseFloat(raw.replace(',', '.'));
 }
 
-const RADIX_KEYS = new Set(['binary', 'hex']);
-
 const BASE_FOR_KEY: Record<string, number> = {
   binary: 2,
   hex: 16,
-};
+} as const;
+
+const RADIX_KEYS = new Set(Object.keys(BASE_FOR_KEY));
 
 const VALID_BASE_PATTERN: Record<number, RegExp> = {
   2: /^[01]+$/,
@@ -80,11 +80,17 @@ function validateNonDecimalKey(
   }
 
   const base = BASE_FOR_KEY[key];
+  let normalizedExpected = expectedStr;
+  if (key === 'hex') {
+    normalizedExpected = normalizeHexAnswer(expectedStr);
+  }
+
   if (!VALID_BASE_PATTERN[base].test(userAnswer)) return false;
-  if (key === 'binary' && userAnswer.length !== expectedStr.length) return false;
+  if (!VALID_BASE_PATTERN[base].test(normalizedExpected)) return false;
+  if (key === 'binary' && userAnswer.length !== normalizedExpected.length) return false;
 
   const userVal = parseInt(userAnswer, base);
-  const expectedVal = parseInt(expectedStr, base);
+  const expectedVal = parseInt(normalizedExpected, base);
   return !isNaN(userVal) && !isNaN(expectedVal) && userVal === expectedVal;
 }
 

--- a/src/app/lib/answerValidation.ts
+++ b/src/app/lib/answerValidation.ts
@@ -28,6 +28,22 @@ export function parseLocaleFloat(raw?: string | null): number {
 }
 
 /**
+ * Returns true when the string has significant leading zeros (e.g. "00011000").
+ * Such values must be compared as strings, not numbers, because parseFloat
+ * strips leading zeros and would incorrectly match "11000" against "00011000".
+ */
+function hasSignificantLeadingZeros(s: string): boolean {
+  return /^0[0-9]+$/.test(s);
+}
+
+/**
+ * Normalise a hex-style user answer by stripping an optional "0x" prefix.
+ */
+function normalizeHexAnswer(s: string): string {
+  return s.replace(/^0x/i, '');
+}
+
+/**
  * Detect the conversion map that applies for the given unit options.
  * Returns null when no conversion-aware check is needed.
  */
@@ -76,8 +92,18 @@ export function validateStructuredAnswer(
       continue;
     }
 
-    const userAnswer = answers[cfg.valueKey]?.trim().toLowerCase();
+    let userAnswer = (answers[cfg.valueKey] ?? '').trim().toLowerCase();
     const expectedStr = String(expected[cfg.valueKey]).toLowerCase();
+
+    if (cfg.valueKey === 'hex') {
+      userAnswer = normalizeHexAnswer(userAnswer);
+    }
+
+    if (hasSignificantLeadingZeros(expectedStr)) {
+      if (userAnswer !== expectedStr) return false;
+      continue;
+    }
+
     const userNum = parseLocaleFloat(userAnswer);
     const expectedNum = parseLocaleFloat(expectedStr);
     const convMap = detectConversionMap(cfg.unitOptions ?? []);
@@ -123,8 +149,18 @@ export function validateStructuredAnswer(
       continue;
     }
 
-    const userAnswer = answers[key]?.trim().toLowerCase();
+    let userAnswer = (answers[key] ?? '').trim().toLowerCase();
     const expectedStr = String(exp).toLowerCase();
+
+    if (key === 'hex') {
+      userAnswer = normalizeHexAnswer(userAnswer);
+    }
+
+    if (hasSignificantLeadingZeros(expectedStr)) {
+      if (userAnswer !== expectedStr) return false;
+      continue;
+    }
+
     const userNum = parseLocaleFloat(userAnswer);
     const expectedNum = parseLocaleFloat(expectedStr);
     if (!isNaN(userNum) && !isNaN(expectedNum)) {
@@ -159,8 +195,18 @@ export function validateQuestionAnswers(
   for (const [key, expected] of Object.entries(question.expectedAnswers)) {
     if (key === 'unit') continue;
 
-    const userAnswer = answers[key]?.trim().toLowerCase();
+    let userAnswer = (answers[key] ?? '').trim().toLowerCase();
     const expectedStr = String(expected).toLowerCase();
+
+    if (key === 'hex') {
+      userAnswer = normalizeHexAnswer(userAnswer);
+    }
+
+    if (hasSignificantLeadingZeros(expectedStr)) {
+      if (userAnswer !== expectedStr) return false;
+      continue;
+    }
+
     const userNum = parseLocaleFloat(userAnswer);
     const expectedNum = parseLocaleFloat(expectedStr);
 


### PR DESCRIPTION
Binary answers were parsed numerically (dropping required leading zeros) and hex inputs with `0x` or zero-padding could be mis-graded or partially parsed.

- **Non-decimal validation**: Extracted `validateNonDecimalKey` to centralize binary/hex handling with base-specific regex, fixed-width binary length checks, and strict parseInt round-trip semantics.
- **Binary handling**: Enforce fixed-width string equality when expected binaries have leading zeros; reject malformed or longer bitstrings.
- **Hex normalization**: Accept `0x`/`0X` prefixes and zero-padded digit-only hex answers without forcing string-only comparison.

Example:

```ts
const nonDecimalResult = validateNonDecimalKey(key, userAnswer, expectedStr);
if (nonDecimalResult !== undefined) {
  if (!nonDecimalResult) return false;
  continue;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strict binary answer validation with required bit-width and leading-zero handling.
  * Hex answer validation accepting case-insensitive digits and optional 0x/0X prefixes.
  * Enhanced structured answer checks supporting binary/hex paths alongside existing formats.

* **Bug Fixes**
  * Rejections added for wrong-width binary, non-binary characters, and non-matching hex values while preserving decimal tolerance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->