### PR TITLE
Split Handelskalkulation into canonical Vorwärts/Rückwärts modules

### DIFF
--- a/src/app/components/ThemeSelector.tsx
+++ b/src/app/components/ThemeSelector.tsx
@@ -23,7 +23,8 @@ const BASE_MODULES = [
   { id: 'cables', name: 'Kabel', icon: Cable, description: 'Kabelauswahl' },
   { id: 'linux', name: 'Linux', icon: Terminal, description: 'Linux-Befehle' },
   { id: 'cloud', name: 'Cloud', icon: Cloud, description: 'Cloud Computing' },
-  { id: 'handelskalkulation', name: 'Kalkulation', icon: Calculator, description: 'Handelskalkulation' },
+  { id: 'handelskalkulation-vorwaerts', name: 'Vorwärtskalk.', icon: Calculator, description: 'LEP → Brutto-VK' },
+  { id: 'handelskalkulation-rueckwaerts', name: 'Rückwärtskalk.', icon: Calculator, description: 'Brutto-VK → LEP' },
 ];
 
 // SQL module requires authentication

--- a/src/app/components/ThemeSelector.tsx
+++ b/src/app/components/ThemeSelector.tsx
@@ -23,8 +23,8 @@ const BASE_MODULES = [
   { id: 'cables', name: 'Kabel', icon: Cable, description: 'Kabelauswahl' },
   { id: 'linux', name: 'Linux', icon: Terminal, description: 'Linux-Befehle' },
   { id: 'cloud', name: 'Cloud', icon: Cloud, description: 'Cloud Computing' },
-  { id: 'handelskalkulation-vorwaerts', name: 'Vorwärtskalk.', icon: Calculator, description: 'LEP → Brutto-VK' },
-  { id: 'handelskalkulation-rueckwaerts', name: 'Rückwärtskalk.', icon: Calculator, description: 'Brutto-VK → LEP' },
+  { id: 'handelskalkulationVorwaerts', name: 'Vorwärtskalk.', icon: Calculator, description: 'LEP → Brutto-VK' },
+  { id: 'handelskalkulationRueckwaerts', name: 'Rückwärtskalk.', icon: Calculator, description: 'Brutto-VK → LEP' },
 ];
 
 // SQL module requires authentication

--- a/src/app/components/__tests__/ThemeSelector.test.tsx
+++ b/src/app/components/__tests__/ThemeSelector.test.tsx
@@ -1,19 +1,25 @@
-import type { ButtonHTMLAttributes } from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import type { ButtonHTMLAttributes } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 // Mock framer-motion to avoid animation complexity in tests
-vi.mock('framer-motion', () => ({
+vi.mock("framer-motion", () => ({
   motion: {
-    button: ({ children, onClick, className }: ButtonHTMLAttributes<HTMLButtonElement>) => (
-      <button onClick={onClick} className={className}>{children}</button>
+    button: ({
+      children,
+      onClick,
+      className,
+    }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button onClick={onClick} className={className}>
+        {children}
+      </button>
     ),
   },
 }));
 
 // Mock lucide-react icons used by ThemeSelector
-vi.mock('lucide-react', () => ({
+vi.mock("lucide-react", () => ({
   Calculator: () => <svg data-testid="icon-calculator" />,
   Image: () => <svg data-testid="icon-image" />,
   Network: () => <svg data-testid="icon-network" />,
@@ -32,81 +38,145 @@ vi.mock('lucide-react', () => ({
   Cloud: () => <svg data-testid="icon-cloud" />,
 }));
 
-import ThemeSelector from '../ThemeSelector';
+import ThemeSelector from "../ThemeSelector";
 
-describe('ThemeSelector - SQL module addition', () => {
+describe("ThemeSelector - SQL module addition", () => {
   const onSelectModule = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('SQL module presence', () => {
-    it('renders the SQL module button when authenticated', () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
+  describe("SQL module presence", () => {
+    it("renders the SQL module button when authenticated", () => {
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
       // There should be multiple "SQL" text nodes (mobile + desktop)
-      const sqlButtons = screen.getAllByText('SQL');
+      const sqlButtons = screen.getAllByText("SQL");
       expect(sqlButtons.length).toBeGreaterThan(0);
     });
 
-it('does not render SQL module when not authenticated', () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={false} />);
-      const sqlButtons = screen.queryAllByText('SQL');
+    it("does not render SQL module when not authenticated", () => {
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={false}
+        />,
+      );
+      const sqlButtons = screen.queryAllByText("SQL");
       expect(sqlButtons.length).toBe(0);
     });
 
     it('renders the SQL module description "Datenbankabfragen" when authenticated', () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const descriptions = screen.getAllByText('Datenbankabfragen');
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const descriptions = screen.getAllByText("Datenbankabfragen");
       expect(descriptions.length).toBeGreaterThan(0);
     });
 
-it('renders the Database icon for the SQL module when authenticated', () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const dbIcons = screen.getAllByTestId('icon-database');
+    it("renders the Database icon for the SQL module when authenticated", () => {
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const dbIcons = screen.getAllByTestId("icon-database");
       expect(dbIcons.length).toBeGreaterThan(0);
     });
 
     it('calls onSelectModule with "sql" when SQL module is clicked (mobile strip)', async () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
 
       // In the mobile strip, find the button by its accessible name containing "SQL"
       // The mobile strip uses regular <button> elements
-      const sqlTexts = screen.getAllByText('SQL');
+      const sqlTexts = screen.getAllByText("SQL");
       // Click the first occurrence (mobile strip button contains just the text and icon)
       await userEvent.click(sqlTexts[0]);
 
-      expect(onSelectModule).toHaveBeenCalledWith('sql');
+      expect(onSelectModule).toHaveBeenCalledWith("sql");
     });
 
     it('marks the SQL module as active when currentModule is "sql"', () => {
-      render(<ThemeSelector currentModule="sql" onSelectModule={onSelectModule} isAuthenticated={true} />);
+      render(
+        <ThemeSelector
+          currentModule="sql"
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
 
       // The active module button should have the emerald active classes
       // We can check by finding buttons that contain "SQL" text and checking their class
-      const sqlTexts = screen.getAllByText('SQL');
+      const sqlTexts = screen.getAllByText("SQL");
       // The parent button of the mobile strip SQL text should have the active class
-      const sqlButton = sqlTexts[0].closest('button');
-      expect(sqlButton).toHaveClass('bg-emerald-500/10');
+      const sqlButton = sqlTexts[0].closest("button");
+      expect(sqlButton).toHaveClass("bg-emerald-500/10");
     });
 
-    it('does not mark SQL module as active when currentModule is something else', () => {
-      render(<ThemeSelector currentModule="binary" onSelectModule={onSelectModule} isAuthenticated={true} />);
+    it("does not mark SQL module as active when currentModule is something else", () => {
+      render(
+        <ThemeSelector
+          currentModule="binary"
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
 
-      const sqlTexts = screen.getAllByText('SQL');
-      const sqlButton = sqlTexts[0].closest('button');
-      expect(sqlButton).not.toHaveClass('bg-emerald-500/10');
+      const sqlTexts = screen.getAllByText("SQL");
+      const sqlButton = sqlTexts[0].closest("button");
+      expect(sqlButton).not.toHaveClass("bg-emerald-500/10");
     });
   });
 
-describe('all modules present', () => {
-    it('renders all 19 module names including Bild-Transfer, Linux, Cloud, Vorwärts/Rückwärtskalk. and SQL when authenticated', () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
+  describe("all modules present", () => {
+    it("renders all 19 module names including Bild-Transfer, Linux, Cloud, Vorwärts/Rückwärtskalk. and SQL when authenticated", () => {
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
 
-const moduleNames = [
-        'Übertragungszeit', 'Bildgröße', 'Bild-Transfer', 'Overhead', 'Subnetting',
-        'Einheiten', 'Binär', 'Hex', 'Hex/Binär', 'Subnetzmaske', 'Aggregation',
-        'Ports', 'OSI', 'Kabel', 'Linux', 'Cloud', 'Vorwärtskalk.', 'Rückwärtskalk.', 'SQL',
+      const moduleNames = [
+        "Übertragungszeit",
+        "Bildgröße",
+        "Bild-Transfer",
+        "Overhead",
+        "Subnetting",
+        "Einheiten",
+        "Binär",
+        "Hex",
+        "Hex/Binär",
+        "Subnetzmaske",
+        "Aggregation",
+        "Ports",
+        "OSI",
+        "Kabel",
+        "Linux",
+        "Cloud",
+        "Vorwärtskalk.",
+        "Rückwärtskalk.",
+        "SQL",
       ];
 
       for (const name of moduleNames) {
@@ -116,13 +186,34 @@ const moduleNames = [
       }
     });
 
-it('renders 18 base modules without SQL when not authenticated', () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={false} />);
+    it("renders 18 base modules without SQL when not authenticated", () => {
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={false}
+        />,
+      );
 
       const moduleNames = [
-        'Übertragungszeit', 'Bildgröße', 'Bild-Transfer', 'Overhead', 'Subnetting',
-        'Einheiten', 'Binär', 'Hex', 'Hex/Binär', 'Subnetzmaske', 'Aggregation',
-        'Ports', 'OSI', 'Kabel', 'Linux', 'Cloud', 'Vorwärtskalk.', 'Rückwärtskalk.',
+        "Übertragungszeit",
+        "Bildgröße",
+        "Bild-Transfer",
+        "Overhead",
+        "Subnetting",
+        "Einheiten",
+        "Binär",
+        "Hex",
+        "Hex/Binär",
+        "Subnetzmaske",
+        "Aggregation",
+        "Ports",
+        "OSI",
+        "Kabel",
+        "Linux",
+        "Cloud",
+        "Vorwärtskalk.",
+        "Rückwärtskalk.",
       ];
 
       for (const name of moduleNames) {
@@ -131,96 +222,166 @@ it('renders 18 base modules without SQL when not authenticated', () => {
       }
 
       // SQL should not be present
-      const sqlButtons = screen.queryAllByText('SQL');
+      const sqlButtons = screen.queryAllByText("SQL");
       expect(sqlButtons.length).toBe(0);
     });
 
-    it('calls onSelectModule with correct id for each module click', async () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
+    it("calls onSelectModule with correct id for each module click", async () => {
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
 
       // Click SQL module
-      const sqlTexts = screen.getAllByText('SQL');
+      const sqlTexts = screen.getAllByText("SQL");
       await userEvent.click(sqlTexts[0]);
-      expect(onSelectModule).toHaveBeenLastCalledWith('sql');
+      expect(onSelectModule).toHaveBeenLastCalledWith("sql");
     });
   });
 
-  describe('module selection behavior', () => {
-    it('passes the selected module id to onSelectModule, not the display name', async () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
+  describe("module selection behavior", () => {
+    it("passes the selected module id to onSelectModule, not the display name", async () => {
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
 
-      const sqlTexts = screen.getAllByText('SQL');
+      const sqlTexts = screen.getAllByText("SQL");
       await userEvent.click(sqlTexts[0]);
 
       // Should pass 'sql' (the id), not 'SQL' (the display name)
-      expect(onSelectModule).toHaveBeenCalledWith('sql');
-      expect(onSelectModule).not.toHaveBeenCalledWith('SQL');
+      expect(onSelectModule).toHaveBeenCalledWith("sql");
+      expect(onSelectModule).not.toHaveBeenCalledWith("SQL");
     });
 
-    it('onSelectModule is called exactly once per click', async () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
+    it("onSelectModule is called exactly once per click", async () => {
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
 
-      const sqlTexts = screen.getAllByText('SQL');
+      const sqlTexts = screen.getAllByText("SQL");
       await userEvent.click(sqlTexts[0]);
 
       expect(onSelectModule).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('handelskalkulation module additions', () => {
+  describe("handelskalkulation module additions", () => {
     it('calls onSelectModule with "handelskalkulationVorwaerts" when Vorwärtskalk. is clicked', async () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const texts = screen.getAllByText('Vorwärtskalk.');
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const texts = screen.getAllByText("Vorwärtskalk.");
       await userEvent.click(texts[0]);
-      expect(onSelectModule).toHaveBeenCalledWith('handelskalkulationVorwaerts');
+      expect(onSelectModule).toHaveBeenCalledWith(
+        "handelskalkulationVorwaerts",
+      );
     });
 
     it('calls onSelectModule with "handelskalkulationRueckwaerts" when Rückwärtskalk. is clicked', async () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const texts = screen.getAllByText('Rückwärtskalk.');
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const texts = screen.getAllByText("Rückwärtskalk.");
       await userEvent.click(texts[0]);
-      expect(onSelectModule).toHaveBeenCalledWith('handelskalkulationRueckwaerts');
+      expect(onSelectModule).toHaveBeenCalledWith(
+        "handelskalkulationRueckwaerts",
+      );
     });
 
     it('marks Vorwärtskalk. as active when currentModule is "handelskalkulationVorwaerts"', () => {
-      render(<ThemeSelector currentModule="handelskalkulationVorwaerts" onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const texts = screen.getAllByText('Vorwärtskalk.');
-      const button = texts[0].closest('button');
-      expect(button).toHaveClass('bg-emerald-500/10');
+      render(
+        <ThemeSelector
+          currentModule="handelskalkulationVorwaerts"
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const texts = screen.getAllByText("Vorwärtskalk.");
+      const button = texts[0].closest("button");
+      expect(button).toHaveClass("bg-emerald-500/10");
     });
 
     it('marks Rückwärtskalk. as active when currentModule is "handelskalkulationRueckwaerts"', () => {
-      render(<ThemeSelector currentModule="handelskalkulationRueckwaerts" onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const texts = screen.getAllByText('Rückwärtskalk.');
-      const button = texts[0].closest('button');
-      expect(button).toHaveClass('bg-emerald-500/10');
+      render(
+        <ThemeSelector
+          currentModule="handelskalkulationRueckwaerts"
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const texts = screen.getAllByText("Rückwärtskalk.");
+      const button = texts[0].closest("button");
+      expect(button).toHaveClass("bg-emerald-500/10");
     });
   });
 
-  describe('imageTransferCombo module addition', () => {
-    it('renders the Bild-Transfer module button', () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const buttons = screen.getAllByText('Bild-Transfer');
+  describe("imageTransferCombo module addition", () => {
+    it("renders the Bild-Transfer module button", () => {
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const buttons = screen.getAllByText("Bild-Transfer");
       expect(buttons.length).toBeGreaterThan(0);
     });
 
     it('calls onSelectModule with "imageTransferCombo" when Bild-Transfer is clicked', async () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const texts = screen.getAllByText('Bild-Transfer');
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const texts = screen.getAllByText("Bild-Transfer");
       await userEvent.click(texts[0]);
-      expect(onSelectModule).toHaveBeenCalledWith('imageTransferCombo');
+      expect(onSelectModule).toHaveBeenCalledWith("imageTransferCombo");
     });
 
     it('marks Bild-Transfer as active when currentModule is "imageTransferCombo"', () => {
-      render(<ThemeSelector currentModule="imageTransferCombo" onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const texts = screen.getAllByText('Bild-Transfer');
-      const button = texts[0].closest('button');
-      expect(button).toHaveClass('bg-emerald-500/10');
+      render(
+        <ThemeSelector
+          currentModule="imageTransferCombo"
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const texts = screen.getAllByText("Bild-Transfer");
+      const button = texts[0].closest("button");
+      expect(button).toHaveClass("bg-emerald-500/10");
     });
 
     it('renders the Bild-Transfer description "Bild + Übertragung"', () => {
-      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
-      const descs = screen.getAllByText('Bild + Übertragung');
+      render(
+        <ThemeSelector
+          currentModule={null}
+          onSelectModule={onSelectModule}
+          isAuthenticated={true}
+        />,
+      );
+      const descs = screen.getAllByText("Bild + Übertragung");
       expect(descs.length).toBeGreaterThan(0);
     });
   });

--- a/src/app/components/__tests__/ThemeSelector.test.tsx
+++ b/src/app/components/__tests__/ThemeSelector.test.tsx
@@ -100,7 +100,7 @@ it('renders the Database icon for the SQL module when authenticated', () => {
   });
 
 describe('all modules present', () => {
-    it('renders all 18 module names including Bild-Transfer, Linux, Cloud, Vorwärts/Rückwärtskalk. and SQL when authenticated', () => {
+    it('renders all 19 module names including Bild-Transfer, Linux, Cloud, Vorwärts/Rückwärtskalk. and SQL when authenticated', () => {
       render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
 
 const moduleNames = [
@@ -116,7 +116,7 @@ const moduleNames = [
       }
     });
 
-it('renders 17 base modules without SQL when not authenticated', () => {
+it('renders 18 base modules without SQL when not authenticated', () => {
       render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={false} />);
 
       const moduleNames = [

--- a/src/app/components/__tests__/ThemeSelector.test.tsx
+++ b/src/app/components/__tests__/ThemeSelector.test.tsx
@@ -20,6 +20,7 @@ vi.mock('lucide-react', () => ({
   ArrowLeftRight: () => <svg data-testid="icon-arrow-left-right" />,
   Binary: () => <svg data-testid="icon-binary" />,
   Hexagon: () => <svg data-testid="icon-hexagon" />,
+  Repeat: () => <svg data-testid="icon-repeat" />,
   Shield: () => <svg data-testid="icon-shield" />,
   Layers: () => <svg data-testid="icon-layers" />,
   Cable: () => <svg data-testid="icon-cable" />,
@@ -99,13 +100,13 @@ it('renders the Database icon for the SQL module when authenticated', () => {
   });
 
 describe('all modules present', () => {
-    it('renders all 17 module names including Bild-Transfer, Linux, Cloud, Kalkulation and SQL when authenticated', () => {
+    it('renders all 18 module names including Bild-Transfer, Linux, Cloud, Vorwärts/Rückwärtskalk. and SQL when authenticated', () => {
       render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
 
 const moduleNames = [
         'Übertragungszeit', 'Bildgröße', 'Bild-Transfer', 'Overhead', 'Subnetting',
-        'Einheiten', 'Binär', 'Hex', 'Subnetzmaske', 'Aggregation',
-        'Ports', 'OSI', 'Kabel', 'Linux', 'Cloud', 'Kalkulation', 'SQL',
+        'Einheiten', 'Binär', 'Hex', 'Hex/Binär', 'Subnetzmaske', 'Aggregation',
+        'Ports', 'OSI', 'Kabel', 'Linux', 'Cloud', 'Vorwärtskalk.', 'Rückwärtskalk.', 'SQL',
       ];
 
       for (const name of moduleNames) {
@@ -115,13 +116,13 @@ const moduleNames = [
       }
     });
 
-it('renders 16 base modules without SQL when not authenticated', () => {
+it('renders 17 base modules without SQL when not authenticated', () => {
       render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={false} />);
 
       const moduleNames = [
         'Übertragungszeit', 'Bildgröße', 'Bild-Transfer', 'Overhead', 'Subnetting',
-        'Einheiten', 'Binär', 'Hex', 'Subnetzmaske', 'Aggregation',
-        'Ports', 'OSI', 'Kabel', 'Linux', 'Cloud', 'Kalkulation',
+        'Einheiten', 'Binär', 'Hex', 'Hex/Binär', 'Subnetzmaske', 'Aggregation',
+        'Ports', 'OSI', 'Kabel', 'Linux', 'Cloud', 'Vorwärtskalk.', 'Rückwärtskalk.',
       ];
 
       for (const name of moduleNames) {

--- a/src/app/components/__tests__/ThemeSelector.test.tsx
+++ b/src/app/components/__tests__/ThemeSelector.test.tsx
@@ -167,6 +167,36 @@ it('renders 18 base modules without SQL when not authenticated', () => {
     });
   });
 
+  describe('handelskalkulation module additions', () => {
+    it('calls onSelectModule with "handelskalkulationVorwaerts" when Vorwärtskalk. is clicked', async () => {
+      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
+      const texts = screen.getAllByText('Vorwärtskalk.');
+      await userEvent.click(texts[0]);
+      expect(onSelectModule).toHaveBeenCalledWith('handelskalkulationVorwaerts');
+    });
+
+    it('calls onSelectModule with "handelskalkulationRueckwaerts" when Rückwärtskalk. is clicked', async () => {
+      render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);
+      const texts = screen.getAllByText('Rückwärtskalk.');
+      await userEvent.click(texts[0]);
+      expect(onSelectModule).toHaveBeenCalledWith('handelskalkulationRueckwaerts');
+    });
+
+    it('marks Vorwärtskalk. as active when currentModule is "handelskalkulationVorwaerts"', () => {
+      render(<ThemeSelector currentModule="handelskalkulationVorwaerts" onSelectModule={onSelectModule} isAuthenticated={true} />);
+      const texts = screen.getAllByText('Vorwärtskalk.');
+      const button = texts[0].closest('button');
+      expect(button).toHaveClass('bg-emerald-500/10');
+    });
+
+    it('marks Rückwärtskalk. as active when currentModule is "handelskalkulationRueckwaerts"', () => {
+      render(<ThemeSelector currentModule="handelskalkulationRueckwaerts" onSelectModule={onSelectModule} isAuthenticated={true} />);
+      const texts = screen.getAllByText('Rückwärtskalk.');
+      const button = texts[0].closest('button');
+      expect(button).toHaveClass('bg-emerald-500/10');
+    });
+  });
+
   describe('imageTransferCombo module addition', () => {
     it('renders the Bild-Transfer module button', () => {
       render(<ThemeSelector currentModule={null} onSelectModule={onSelectModule} isAuthenticated={true} />);

--- a/src/app/lib/__tests__/moduleIds.test.ts
+++ b/src/app/lib/__tests__/moduleIds.test.ts
@@ -63,4 +63,53 @@ describe("module ID compatibility helpers", () => {
       last_session: "2026-04-02T08:00:00.000Z",
     });
   });
+
+  it("merges legacy and canonical Handelskalkulation split IDs", () => {
+    const normalized = normalizeProgressModules([
+      {
+        module: "handelskalkulation-vorwaerts",
+        questions_attempted: 1,
+        questions_correct: 1,
+        streak_days: 1,
+        last_session: "2026-04-01T08:00:00.000Z",
+      },
+      {
+        module: "handelskalkulationVorwaerts",
+        questions_attempted: 2,
+        questions_correct: 1,
+        streak_days: 3,
+        last_session: "2026-04-02T08:00:00.000Z",
+      },
+    ]);
+
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]).toMatchObject({
+      module: "handelskalkulationVorwaerts",
+      questions_attempted: 3,
+      questions_correct: 2,
+      streak_days: 3,
+      last_session: "2026-04-02T08:00:00.000Z",
+    });
+  });
+
+  it("keeps legacy combined handelskalkulation progress unchanged", () => {
+    const normalized = normalizeProgressModules([
+      {
+        module: "handelskalkulation",
+        questions_attempted: 5,
+        questions_correct: 4,
+        streak_days: 2,
+        last_session: "2026-04-03T08:00:00.000Z",
+      },
+    ]);
+
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]).toMatchObject({
+      module: "handelskalkulation",
+      questions_attempted: 5,
+      questions_correct: 4,
+      streak_days: 2,
+      last_session: "2026-04-03T08:00:00.000Z",
+    });
+  });
 });

--- a/src/app/lib/__tests__/moduleIds.test.ts
+++ b/src/app/lib/__tests__/moduleIds.test.ts
@@ -13,6 +13,7 @@ describe('module ID compatibility helpers', () => {
     expect(toCanonicalModuleId('image-transfer-combo')).toBe('imageTransferCombo');
     expect(toCanonicalModuleId('handelskalkulation-vorwaerts')).toBe('handelskalkulationVorwaerts');
     expect(toCanonicalModuleId('handelskalkulation-rueckwaerts')).toBe('handelskalkulationRueckwaerts');
+    expect(toCanonicalModuleId('handelskalkulation')).toBe('handelskalkulationVorwaerts');
   });
 
   it('maps canonical IDs back to stored progress IDs for backward compatibility', () => {

--- a/src/app/lib/__tests__/moduleIds.test.ts
+++ b/src/app/lib/__tests__/moduleIds.test.ts
@@ -11,6 +11,8 @@ describe('module ID compatibility helpers', () => {
     expect(toCanonicalModuleId('image-calc')).toBe('imageCalc');
     expect(toCanonicalModuleId('unit-conversion')).toBe('unitConversion');
     expect(toCanonicalModuleId('image-transfer-combo')).toBe('imageTransferCombo');
+    expect(toCanonicalModuleId('handelskalkulation-vorwaerts')).toBe('handelskalkulationVorwaerts');
+    expect(toCanonicalModuleId('handelskalkulation-rueckwaerts')).toBe('handelskalkulationRueckwaerts');
   });
 
   it('maps canonical IDs back to stored progress IDs for backward compatibility', () => {

--- a/src/app/lib/__tests__/moduleIds.test.ts
+++ b/src/app/lib/__tests__/moduleIds.test.ts
@@ -1,54 +1,66 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
 import {
   normalizeProgressModules,
   toCanonicalModuleId,
   toStoredProgressModuleId,
-} from '../moduleIds';
+} from "../moduleIds";
 
-describe('module ID compatibility helpers', () => {
-  it('maps legacy module IDs to canonical UI IDs', () => {
-    expect(toCanonicalModuleId('image-calc')).toBe('imageCalc');
-    expect(toCanonicalModuleId('unit-conversion')).toBe('unitConversion');
-    expect(toCanonicalModuleId('image-transfer-combo')).toBe('imageTransferCombo');
-    expect(toCanonicalModuleId('handelskalkulation-vorwaerts')).toBe('handelskalkulationVorwaerts');
-    expect(toCanonicalModuleId('handelskalkulation-rueckwaerts')).toBe('handelskalkulationRueckwaerts');
-    expect(toCanonicalModuleId('handelskalkulation')).toBe('handelskalkulationVorwaerts');
+describe("module ID compatibility helpers", () => {
+  it("maps legacy module IDs to canonical UI IDs", () => {
+    expect(toCanonicalModuleId("image-calc")).toBe("imageCalc");
+    expect(toCanonicalModuleId("unit-conversion")).toBe("unitConversion");
+    expect(toCanonicalModuleId("image-transfer-combo")).toBe(
+      "imageTransferCombo",
+    );
+    expect(toCanonicalModuleId("handelskalkulation-vorwaerts")).toBe(
+      "handelskalkulationVorwaerts",
+    );
+    expect(toCanonicalModuleId("handelskalkulation-rueckwaerts")).toBe(
+      "handelskalkulationRueckwaerts",
+    );
+    expect(toCanonicalModuleId("handelskalkulation")).toBe("handelskalkulation");
   });
 
-  it('maps canonical IDs back to stored progress IDs for backward compatibility', () => {
-    expect(toStoredProgressModuleId('imageCalc')).toBe('image-calc');
-    expect(toStoredProgressModuleId('unitConversion')).toBe('unit-conversion');
-    expect(toStoredProgressModuleId('imageTransferCombo')).toBe('image-transfer-combo');
-    expect(toStoredProgressModuleId('handelskalkulationVorwaerts')).toBe('handelskalkulation-vorwaerts');
-    expect(toStoredProgressModuleId('handelskalkulationRueckwaerts')).toBe('handelskalkulation-rueckwaerts');
+  it("maps canonical IDs back to stored progress IDs for backward compatibility", () => {
+    expect(toStoredProgressModuleId("imageCalc")).toBe("image-calc");
+    expect(toStoredProgressModuleId("unitConversion")).toBe("unit-conversion");
+    expect(toStoredProgressModuleId("imageTransferCombo")).toBe(
+      "image-transfer-combo",
+    );
+    expect(toStoredProgressModuleId("handelskalkulationVorwaerts")).toBe(
+      "handelskalkulation-vorwaerts",
+    );
+    expect(toStoredProgressModuleId("handelskalkulationRueckwaerts")).toBe(
+      "handelskalkulation-rueckwaerts",
+    );
   });
 
-  it('merges legacy and canonical progress rows into one canonical module entry', () => {
+  it("merges legacy and canonical progress rows into one canonical module entry", () => {
     const normalized = normalizeProgressModules([
       {
-        module: 'image-calc',
+        module: "image-calc",
         questions_attempted: 3,
         questions_correct: 2,
         streak_days: 1,
-        last_session: '2026-04-01T08:00:00.000Z',
+        last_session: "2026-04-01T08:00:00.000Z",
       },
       {
-        module: 'imageCalc',
+        module: "imageCalc",
         questions_attempted: 4,
         questions_correct: 3,
         streak_days: 2,
-        last_session: '2026-04-02T08:00:00.000Z',
+        last_session: "2026-04-02T08:00:00.000Z",
       },
     ]);
 
     expect(normalized).toHaveLength(1);
     expect(normalized[0]).toMatchObject({
-      module: 'imageCalc',
+      module: "imageCalc",
       questions_attempted: 7,
       questions_correct: 5,
       streak_days: 2,
-      last_session: '2026-04-02T08:00:00.000Z',
+      last_session: "2026-04-02T08:00:00.000Z",
     });
   });
 });

--- a/src/app/lib/__tests__/moduleIds.test.ts
+++ b/src/app/lib/__tests__/moduleIds.test.ts
@@ -19,6 +19,8 @@ describe('module ID compatibility helpers', () => {
     expect(toStoredProgressModuleId('imageCalc')).toBe('image-calc');
     expect(toStoredProgressModuleId('unitConversion')).toBe('unit-conversion');
     expect(toStoredProgressModuleId('imageTransferCombo')).toBe('image-transfer-combo');
+    expect(toStoredProgressModuleId('handelskalkulationVorwaerts')).toBe('handelskalkulation-vorwaerts');
+    expect(toStoredProgressModuleId('handelskalkulationRueckwaerts')).toBe('handelskalkulation-rueckwaerts');
   });
 
   it('merges legacy and canonical progress rows into one canonical module entry', () => {

--- a/src/app/lib/generators/__tests__/handelskalkulation.test.ts
+++ b/src/app/lib/generators/__tests__/handelskalkulation.test.ts
@@ -90,7 +90,7 @@ describe('handelskalkulation generator', () => {
     const question = generateVorwaertsKalkulationQuestion();
 
     expect(question.module).toBe('handelskalkulationVorwaerts');
-    expect(question.id).toMatch(/^handelskalkulationVorwaerts-\d+$/);
+    expect(question.id).toMatch(/^handelskalkulationVorwaerts-[a-f0-9]+$/);
     expect(question.answerInputs).toBeDefined();
     expect(question.answerInputs!.length).toBeGreaterThan(0);
     expect(question.answerInputs!.some((input) => input.valueKey === 'bruttovk')).toBe(true);
@@ -101,7 +101,7 @@ describe('handelskalkulation generator', () => {
     const question = generateRueckwaertsKalkulationQuestion();
 
     expect(question.module).toBe('handelskalkulationRueckwaerts');
-    expect(question.id).toMatch(/^handelskalkulationRueckwaerts-\d+$/);
+    expect(question.id).toMatch(/^handelskalkulationRueckwaerts-[a-f0-9]+$/);
     expect(question.answerInputs).toBeDefined();
     expect(question.answerInputs!.length).toBeGreaterThan(0);
     expect(question.answerInputs!.some((input) => input.valueKey === 'lep')).toBe(true);

--- a/src/app/lib/generators/__tests__/handelskalkulation.test.ts
+++ b/src/app/lib/generators/__tests__/handelskalkulation.test.ts
@@ -4,6 +4,7 @@ import {
   generateDifferenzCalculation,
   generateHandelskalkulationQuestion,
   generateRueckwaertsCalculation,
+  generateVorwaertsCalculation,
   generateVorwaertsKalkulationQuestion,
   generateRueckwaertsKalkulationQuestion,
 } from '../handelskalkulation';
@@ -15,6 +16,19 @@ function expectMoneyClose(actual: number, expected: number) {
 describe('handelskalkulation generator', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('produces consistent vorwärts calculations', () => {
+    for (let i = 0; i < 25; i += 1) {
+      const { given, calculated } = generateVorwaertsCalculation();
+
+      expectMoneyClose(calculated.lep - calculated.rabatt, calculated.zep);
+      expectMoneyClose(calculated.zep - calculated.skonto, calculated.bep);
+      expectMoneyClose(calculated.bep + given.bezugskosten, calculated.bp);
+      expectMoneyClose(calculated.bp + calculated.handlungskosten, calculated.selbstkosten);
+      expectMoneyClose(calculated.selbstkosten + calculated.gewinn, calculated.bvp);
+      expectMoneyClose(calculated.nettovk + calculated.ust, calculated.bruttovk);
+    }
   });
 
   it('produces consistent rückwärts calculations without negative discount amounts', () => {

--- a/src/app/lib/generators/__tests__/handelskalkulation.test.ts
+++ b/src/app/lib/generators/__tests__/handelskalkulation.test.ts
@@ -4,6 +4,8 @@ import {
   generateDifferenzCalculation,
   generateHandelskalkulationQuestion,
   generateRueckwaertsCalculation,
+  generateVorwaertsKalkulationQuestion,
+  generateRueckwaertsKalkulationQuestion,
 } from '../handelskalkulation';
 
 function expectMoneyClose(actual: number, expected: number) {
@@ -82,6 +84,47 @@ describe('handelskalkulation generator', () => {
     expect(steps).toMatch(/Selbstkosten = .* \/ 1,\d{2} = .*/);
     expect(steps).toMatch(/ZEP = .* \/ 0,\d{2} = .*/);
     expect(steps).toMatch(/LEP netto = .* \/ 0,\d{2} = .*/);
+  });
+
+  it('generateVorwaertsKalkulationQuestion sets correct module and id prefix', () => {
+    const question = generateVorwaertsKalkulationQuestion();
+
+    expect(question.module).toBe('handelskalkulationVorwaerts');
+    expect(question.id).toMatch(/^handelskalkulationVorwaerts-\d+$/);
+    expect(question.answerInputs).toBeDefined();
+    expect(question.answerInputs!.length).toBeGreaterThan(0);
+    expect(question.answerInputs!.some((input) => input.valueKey === 'bruttovk')).toBe(true);
+    expect(question.solutionSteps.length).toBeGreaterThan(0);
+  });
+
+  it('generateRueckwaertsKalkulationQuestion sets correct module and id prefix', () => {
+    const question = generateRueckwaertsKalkulationQuestion();
+
+    expect(question.module).toBe('handelskalkulationRueckwaerts');
+    expect(question.id).toMatch(/^handelskalkulationRueckwaerts-\d+$/);
+    expect(question.answerInputs).toBeDefined();
+    expect(question.answerInputs!.length).toBeGreaterThan(0);
+    expect(question.answerInputs!.some((input) => input.valueKey === 'lep')).toBe(true);
+    expect(question.solutionSteps.length).toBeGreaterThan(0);
+  });
+
+  it('generateVorwaertsKalkulationQuestion never produces rueckwaerts or differenz questions', () => {
+    for (let i = 0; i < 20; i += 1) {
+      const question = generateVorwaertsKalkulationQuestion();
+      expect(question.module).toBe('handelskalkulationVorwaerts');
+      expect(question.answerInputs!.some((input) => input.valueKey === 'differenz')).toBe(false);
+    }
+  });
+
+  it('generateRueckwaertsKalkulationQuestion never produces vorwaerts or differenz questions', () => {
+    for (let i = 0; i < 20; i += 1) {
+      const question = generateRueckwaertsKalkulationQuestion();
+      expect(question.module).toBe('handelskalkulationRueckwaerts');
+      expect(question.answerInputs!.some((input) => input.valueKey === 'differenz')).toBe(false);
+      // bruttovk is given in rückwärts, lep is the final computed answer
+      expect(question.answerInputs!.some((input) => input.valueKey === 'bruttovk')).toBe(false);
+      expect(question.answerInputs!.some((input) => input.valueKey === 'lep')).toBe(true);
+    }
   });
 
   it('renders differenz backward solution steps with specific decimal markup and discount factors', () => {

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -470,6 +470,9 @@ function buildQuestion(
   backwardSteps?: Record<string, number>,
   moduleId?: string
 ): Question {
+  if (type === 'differenz' && (!forwardSteps || !backwardSteps)) {
+    throw new Error('buildQuestion: forwardSteps and backwardSteps are required for differenz type');
+  }
   const typeLabel = type === 'vorwaerts'
     ? 'Vorwärtskalkulation'
     : type === 'rueckwaerts'

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -153,16 +153,49 @@ function buildAnswerInputs(
     }));
 }
 
-export function generateVorwaertsCalculation(): GeneratedKalkulation {
-  const lepBrutto = randomAmount(100, 1500);
-  const ustRate = 19;
-  const lieferRabatt = randomPercent(5, 20);
-  const lieferskonto = randomPercent(1, 4);
-  const bezugskosten = randomAmount(5, 80);
-  const handlungsKosten = randomPercent(25, 60);
-  const gewinnZuschlag = randomPercent(8, 25);
-  const kundenSkonto = randomPercent(2, 5);
-  const kundenRabatt = randomPercent(5, 20);
+/** Shared calculation chain — single source of truth for all kalkulation types. */
+interface BaseKalkulationParams {
+  lepBrutto: number;
+  ustRate: number;
+  lieferRabatt: number;
+  lieferskonto: number;
+  bezugskosten: number;
+  handlungsKosten: number;
+  gewinnZuschlag: number;
+  kundenSkonto: number;
+  kundenRabatt: number;
+}
+
+interface BaseKalkulationChain {
+  params: BaseKalkulationParams;
+  lepNettoStep: ReturnType<typeof reverseMarkup>;
+  rabattStep: ReturnType<typeof applyDeduction>;
+  skontoStep: ReturnType<typeof applyDeduction>;
+  bp: number;
+  handlungskostenStep: ReturnType<typeof applyMarkup>;
+  gewinnStep: ReturnType<typeof applyMarkup>;
+  kundenskontoStep: ReturnType<typeof reverseDiscount>;
+  kundenrabattStep: ReturnType<typeof reverseDiscount>;
+  ustStep: ReturnType<typeof applyMarkup>;
+}
+
+function randomKalkulationParams(): BaseKalkulationParams {
+  return {
+    lepBrutto: randomAmount(100, 1500),
+    ustRate: 19,
+    lieferRabatt: randomPercent(5, 20),
+    lieferskonto: randomPercent(1, 4),
+    bezugskosten: randomAmount(5, 80),
+    handlungsKosten: randomPercent(25, 60),
+    gewinnZuschlag: randomPercent(8, 25),
+    kundenSkonto: randomPercent(2, 5),
+    kundenRabatt: randomPercent(5, 20),
+  };
+}
+
+function computeKalkulationChain(params: BaseKalkulationParams): BaseKalkulationChain {
+  const { lepBrutto, ustRate, lieferRabatt, lieferskonto, bezugskosten,
+    handlungsKosten, gewinnZuschlag, kundenSkonto, kundenRabatt } = params;
 
   const lepNettoStep = reverseMarkup(lepBrutto, ustRate);
   const rabattStep = applyDeduction(lepNettoStep.base, lieferRabatt);
@@ -174,116 +207,95 @@ export function generateVorwaertsCalculation(): GeneratedKalkulation {
   const kundenrabattStep = reverseDiscount(kundenskontoStep.base, kundenRabatt);
   const ustStep = applyMarkup(kundenrabattStep.base, ustRate);
 
+  return {
+    params, lepNettoStep, rabattStep, skontoStep, bp,
+    handlungskostenStep, gewinnStep, kundenskontoStep, kundenrabattStep, ustStep,
+  };
+}
+
+export function generateVorwaertsCalculation(): GeneratedKalkulation {
+  const params = randomKalkulationParams();
+  const chain = computeKalkulationChain(params);
+
   const calculated = toRoundedRecord({
-    lep: lepNettoStep.base,
-    rabatt: rabattStep.amount,
-    zep: rabattStep.remaining,
-    skonto: skontoStep.amount,
-    bep: skontoStep.remaining,
-    bezugskosten,
-    bp,
-    handlungskosten: handlungskostenStep.amount,
-    selbstkosten: handlungskostenStep.total,
-    gewinn: gewinnStep.amount,
-    bvp: gewinnStep.total,
-    kundenskonto: kundenskontoStep.amount,
-    zvp: kundenskontoStep.base,
-    kundenrabatt: kundenrabattStep.amount,
-    nettovk: kundenrabattStep.base,
-    ust: ustStep.amount,
-    bruttovk: ustStep.total,
+    lep: chain.lepNettoStep.base,
+    rabatt: chain.rabattStep.amount,
+    zep: chain.rabattStep.remaining,
+    skonto: chain.skontoStep.amount,
+    bep: chain.skontoStep.remaining,
+    bezugskosten: params.bezugskosten,
+    bp: chain.bp,
+    handlungskosten: chain.handlungskostenStep.amount,
+    selbstkosten: chain.handlungskostenStep.total,
+    gewinn: chain.gewinnStep.amount,
+    bvp: chain.gewinnStep.total,
+    kundenskonto: chain.kundenskontoStep.amount,
+    zvp: chain.kundenskontoStep.base,
+    kundenrabatt: chain.kundenrabattStep.amount,
+    nettovk: chain.kundenrabattStep.base,
+    ust: chain.ustStep.amount,
+    bruttovk: chain.ustStep.total,
   });
 
   const given: Record<string, number> = {
-    lepBrutto: round2(lepBrutto),
-    ustRate,
-    lieferRabatt,
-    lieferskonto,
-    bezugskosten: round2(bezugskosten),
-    handlungsKosten,
-    gewinnZuschlag,
-    kundenSkonto,
-    kundenRabatt,
+    lepBrutto: round2(params.lepBrutto),
+    ustRate: params.ustRate,
+    lieferRabatt: params.lieferRabatt,
+    lieferskonto: params.lieferskonto,
+    bezugskosten: round2(params.bezugskosten),
+    handlungsKosten: params.handlungsKosten,
+    gewinnZuschlag: params.gewinnZuschlag,
+    kundenSkonto: params.kundenSkonto,
+    kundenRabatt: params.kundenRabatt,
   };
 
   return { given, calculated, schema: VORWAERTS_SCHEMA };
 }
 
 export function generateRueckwaertsCalculation(): GeneratedKalkulation {
-  const lepBrutto = randomAmount(100, 1500);
-  const ustRate = 19;
-  const lieferRabatt = randomPercent(5, 20);
-  const lieferskonto = randomPercent(1, 4);
-  const bezugskosten = randomAmount(5, 80);
-  const handlungsKosten = randomPercent(25, 60);
-  const gewinnZuschlag = randomPercent(8, 25);
-  const kundenSkonto = randomPercent(2, 5);
-  const kundenRabatt = randomPercent(5, 20);
-
-  const lepNettoStep = reverseMarkup(lepBrutto, ustRate);
-  const rabattStep = applyDeduction(lepNettoStep.base, lieferRabatt);
-  const skontoStep = applyDeduction(rabattStep.remaining, lieferskonto);
-  const bp = skontoStep.remaining + bezugskosten;
-  const handlungskostenStep = applyMarkup(bp, handlungsKosten);
-  const gewinnStep = applyMarkup(handlungskostenStep.total, gewinnZuschlag);
-  const kundenskontoStep = reverseDiscount(gewinnStep.total, kundenSkonto);
-  const kundenrabattStep = reverseDiscount(kundenskontoStep.base, kundenRabatt);
-  const ustStep = applyMarkup(kundenrabattStep.base, ustRate);
+  const params = randomKalkulationParams();
+  const chain = computeKalkulationChain(params);
 
   const calculated = toRoundedRecord({
-    ust: ustStep.amount,
-    nettovk: kundenrabattStep.base,
-    kundenrabatt: kundenrabattStep.amount,
-    zvp: kundenskontoStep.base,
-    kundenskonto: kundenskontoStep.amount,
-    bvp: gewinnStep.total,
-    gewinn: gewinnStep.amount,
-    selbstkosten: handlungskostenStep.total,
-    handlungskosten: handlungskostenStep.amount,
-    bp,
-    bezugskosten,
-    bep: skontoStep.remaining,
-    skonto: skontoStep.amount,
-    zep: rabattStep.remaining,
-    rabatt: rabattStep.amount,
-    lep: lepNettoStep.base,
+    ust: chain.ustStep.amount,
+    nettovk: chain.kundenrabattStep.base,
+    kundenrabatt: chain.kundenrabattStep.amount,
+    zvp: chain.kundenskontoStep.base,
+    kundenskonto: chain.kundenskontoStep.amount,
+    bvp: chain.gewinnStep.total,
+    gewinn: chain.gewinnStep.amount,
+    selbstkosten: chain.handlungskostenStep.total,
+    handlungskosten: chain.handlungskostenStep.amount,
+    bp: chain.bp,
+    bezugskosten: params.bezugskosten,
+    bep: chain.skontoStep.remaining,
+    skonto: chain.skontoStep.amount,
+    zep: chain.rabattStep.remaining,
+    rabatt: chain.rabattStep.amount,
+    lep: chain.lepNettoStep.base,
   });
 
   const given: Record<string, number> = {
-    bruttovk: round2(ustStep.total),
-    ustRate,
-    kundenRabatt,
-    kundenSkonto,
-    gewinnZuschlag,
-    handlungsKosten,
-    bezugskosten: round2(bezugskosten),
-    lieferskonto,
-    lieferRabatt,
+    bruttovk: round2(chain.ustStep.total),
+    ustRate: params.ustRate,
+    kundenRabatt: params.kundenRabatt,
+    kundenSkonto: params.kundenSkonto,
+    gewinnZuschlag: params.gewinnZuschlag,
+    handlungsKosten: params.handlungsKosten,
+    bezugskosten: round2(params.bezugskosten),
+    lieferskonto: params.lieferskonto,
+    lieferRabatt: params.lieferRabatt,
   };
 
   return { given, calculated, schema: RUECKWAERTS_SCHEMA };
 }
 
 export function generateDifferenzCalculation(): GeneratedDifferenz {
-  const lepBrutto = randomAmount(100, 1500);
-  const ustRate = 19;
-  const lieferRabatt = randomPercent(5, 20);
-  const lieferskonto = randomPercent(1, 4);
-  const bezugskosten = randomAmount(5, 80);
-  const handlungsKosten = randomPercent(25, 60);
-  const gewinnZuschlag = randomPercent(8, 25);
-  const kundenSkonto = randomPercent(2, 5);
-  const kundenRabatt = randomPercent(5, 20);
-
-  const lepNettoStep = reverseMarkup(lepBrutto, ustRate);
-  const rabattStep = applyDeduction(lepNettoStep.base, lieferRabatt);
-  const skontoStep = applyDeduction(rabattStep.remaining, lieferskonto);
-  const bp = skontoStep.remaining + bezugskosten;
-  const handlungskostenStep = applyMarkup(bp, handlungsKosten);
-  const gewinnStep = applyMarkup(handlungskostenStep.total, gewinnZuschlag);
-  const kundenskontoStep = reverseDiscount(gewinnStep.total, kundenSkonto);
-  const kundenrabattStep = reverseDiscount(kundenskontoStep.base, kundenRabatt);
-  const ustForwardStep = applyMarkup(kundenrabattStep.base, ustRate);
+  const params = randomKalkulationParams();
+  const chain = computeKalkulationChain(params);
+  const { ustRate, lieferRabatt, lieferskonto, bezugskosten,
+    handlungsKosten, gewinnZuschlag, kundenSkonto, kundenRabatt } = params;
+  const ustForwardStep = chain.ustStep;
 
   const buildBackwardFromMarket = (marketBruttovk: number) => {
     const ustBackwardStep = reverseMarkup(marketBruttovk, ustRate);
@@ -368,21 +380,21 @@ export function generateDifferenzCalculation(): GeneratedDifferenz {
   } = backwardMarket;
 
   const forwardSteps = toRoundedRecord({
-    lep: lepNettoStep.base,
-    rabatt: rabattStep.amount,
-    zep: rabattStep.remaining,
-    skonto: skontoStep.amount,
-    bep: skontoStep.remaining,
+    lep: chain.lepNettoStep.base,
+    rabatt: chain.rabattStep.amount,
+    zep: chain.rabattStep.remaining,
+    skonto: chain.skontoStep.amount,
+    bep: chain.skontoStep.remaining,
     bezugskosten,
-    bp,
-    handlungskosten: handlungskostenStep.amount,
-    selbstkosten: handlungskostenStep.total,
-    gewinn: gewinnStep.amount,
-    bvp: gewinnStep.total,
-    kundenskonto: kundenskontoStep.amount,
-    zvp: kundenskontoStep.base,
-    kundenrabatt: kundenrabattStep.amount,
-    nettovk: kundenrabattStep.base,
+    bp: chain.bp,
+    handlungskosten: chain.handlungskostenStep.amount,
+    selbstkosten: chain.handlungskostenStep.total,
+    gewinn: chain.gewinnStep.amount,
+    bvp: chain.gewinnStep.total,
+    kundenskonto: chain.kundenskontoStep.amount,
+    zvp: chain.kundenskontoStep.base,
+    kundenrabatt: chain.kundenrabattStep.amount,
+    nettovk: chain.kundenrabattStep.base,
     ust: ustForwardStep.amount,
     bruttovk: ustForwardStep.total,
   });
@@ -409,7 +421,7 @@ export function generateDifferenzCalculation(): GeneratedDifferenz {
   const differenz = round2(bruttovkMarkt - forwardSteps.bruttovk);
 
   const given: Record<string, number> = {
-    lepBrutto: round2(lepBrutto),
+    lepBrutto: round2(params.lepBrutto),
     ustRate,
     lieferRabatt,
     lieferskonto,
@@ -450,7 +462,8 @@ function buildQuestion(
   calculated: Record<string, number>,
   schema: KalkulationStep[],
   forwardSteps?: Record<string, number>,
-  backwardSteps?: Record<string, number>
+  backwardSteps?: Record<string, number>,
+  moduleId?: string
 ): Question {
   const typeLabel = type === 'vorwaerts'
     ? 'Vorwärtskalkulation'
@@ -554,7 +567,7 @@ function buildQuestion(
     solutionSteps.push(`Skonto = ${formatEuro(backwardSteps.zep)} − ${formatEuro(backwardSteps.bep)} = ${formatEuro(backwardSteps.skonto)}`);
     solutionSteps.push(`LEP netto = ${formatEuro(backwardSteps.zep)} / ${formatDiscountFactor(given.lieferRabatt)} = ${formatEuro(backwardSteps.lep)}`);
     solutionSteps.push(`Rabatt = ${formatEuro(backwardSteps.lep)} − ${formatEuro(backwardSteps.zep)} = ${formatEuro(backwardSteps.rabatt)}`);
-    solutionSteps.push(`LEP brutto = ${formatEuro(backwardSteps.lep)} × 1,19 = ${formatEuro(backwardSteps.lep * 1.19)}`);
+    solutionSteps.push(`LEP brutto = ${formatEuro(backwardSteps.lep)} × 1,19 = ${formatEuro(round2(backwardSteps.lep * 1.19))}`);
     solutionSteps.push('');
 
     const differenz = calculated.differenz as number;
@@ -613,7 +626,7 @@ function buildQuestion(
       solutionSteps.push(`Skonto = ${formatEuro(calculated.zep as number)} − ${formatEuro(calculated.bep as number)} = ${formatEuro(calculated.skonto as number)}`);
       solutionSteps.push(`LEP netto = ${formatEuro(calculated.zep as number)} / ${formatDiscountFactor(given.lieferRabatt)} = ${formatEuro(calculated.lep as number)}`);
       solutionSteps.push(`Rabatt = ${formatEuro(calculated.lep as number)} − ${formatEuro(calculated.zep as number)} = ${formatEuro(calculated.rabatt as number)}`);
-      solutionSteps.push(`LEP brutto = ${formatEuro(calculated.lep as number)} × 1,19 = ${formatEuro((calculated.lep as number) * 1.19)}`);
+      solutionSteps.push(`LEP brutto = ${formatEuro(calculated.lep as number)} × 1,19 = ${formatEuro(round2((calculated.lep as number) * 1.19))}`);
     }
   }
 
@@ -621,9 +634,9 @@ function buildQuestion(
     type === 'vorwaerts' ? 'medium' : 'hard';
 
   return {
-    id: `handelskalkulation-${Date.now()}`,
+    id: `${moduleId ?? 'handelskalkulation'}-${Date.now()}`,
     theme: 'Wirtschaftsrechnen',
-    module: 'handelskalkulation',
+    module: moduleId ?? 'handelskalkulation',
     questionText: frage,
     expectedAnswers,
     solutionSteps,
@@ -634,32 +647,36 @@ function buildQuestion(
 
 export function generateVorwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateVorwaertsCalculation();
-  const q = buildQuestion('vorwaerts', given, calculated, schema);
-  return { ...q, id: `handelskalkulationVorwaerts-${Date.now()}`, module: 'handelskalkulationVorwaerts' };
+  return buildQuestion('vorwaerts', given, calculated, schema, undefined, undefined, 'handelskalkulationVorwaerts');
 }
 
 export function generateRueckwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateRueckwaertsCalculation();
-  const q = buildQuestion('rueckwaerts', given, calculated, schema);
-  return { ...q, id: `handelskalkulationRueckwaerts-${Date.now()}`, module: 'handelskalkulationRueckwaerts' };
+  return buildQuestion('rueckwaerts', given, calculated, schema, undefined, undefined, 'handelskalkulationRueckwaerts');
 }
 
 export function generateHandelskalkulationQuestion(): Question {
   const rand = Math.random();
   const type: KalkulationType = rand < 0.333 ? 'vorwaerts' : rand < 0.666 ? 'rueckwaerts' : 'differenz';
 
-  if (type === 'vorwaerts') {
+  try {
+    if (type === 'vorwaerts') {
+      const { given, calculated, schema } = generateVorwaertsCalculation();
+      return buildQuestion(type, given, calculated, schema);
+    }
+
+    if (type === 'rueckwaerts') {
+      const { given, calculated, schema } = generateRueckwaertsCalculation();
+      return buildQuestion(type, given, calculated, schema);
+    }
+
+    const { given, calculated, forwardSteps, backwardSteps, schema } = generateDifferenzCalculation();
+    return buildQuestion(type, given, calculated, schema, forwardSteps, backwardSteps);
+  } catch {
+    // DifferenzCalculation can fail to find valid values — fallback to vorwaerts
     const { given, calculated, schema } = generateVorwaertsCalculation();
-    return buildQuestion(type, given, calculated, schema);
+    return buildQuestion('vorwaerts', given, calculated, schema);
   }
-
-  if (type === 'rueckwaerts') {
-    const { given, calculated, schema } = generateRueckwaertsCalculation();
-    return buildQuestion(type, given, calculated, schema);
-  }
-
-  const { given, calculated, forwardSteps, backwardSteps, schema } = generateDifferenzCalculation();
-  return buildQuestion(type, given, calculated, schema, forwardSteps, backwardSteps);
 }
 
 export { VORWAERTS_SCHEMA, RUECKWAERTS_SCHEMA };

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -632,6 +632,16 @@ function buildQuestion(
   };
 }
 
+export function generateVorwaertsKalkulationQuestion(): Question {
+  const { given, calculated, schema } = generateVorwaertsCalculation();
+  return buildQuestion('vorwaerts', given, calculated, schema);
+}
+
+export function generateRueckwaertsKalkulationQuestion(): Question {
+  const { given, calculated, schema } = generateRueckwaertsCalculation();
+  return buildQuestion('rueckwaerts', given, calculated, schema);
+}
+
 export function generateHandelskalkulationQuestion(): Question {
   const rand = Math.random();
   const type: KalkulationType = rand < 0.333 ? 'vorwaerts' : rand < 0.666 ? 'rueckwaerts' : 'differenz';

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -6,7 +6,6 @@ interface KalkulationStep {
   label: string;
   key: string;
   isPercentage?: boolean;
-  isResult?: boolean;
 }
 
 interface GeneratedKalkulation {
@@ -21,12 +20,12 @@ interface GeneratedDifferenz extends GeneratedKalkulation {
 }
 
 const VORWAERTS_SCHEMA: KalkulationStep[] = [
-  { label: 'Listeneinkaufspreis (LEP)', key: 'lep', isResult: true },
+  { label: 'Listeneinkaufspreis (LEP)', key: 'lep' },
   { label: '− Lieferantenrabatt', key: 'rabatt', isPercentage: true },
   { label: '= Zieleinkaufspreis (ZEP)', key: 'zep' },
   { label: '− Lieferskonto', key: 'skonto', isPercentage: true },
   { label: '= Bareinkaufspreis (BEP)', key: 'bep' },
-  { label: '+ Bezugskosten', key: 'bezugskosten', isResult: true },
+  { label: '+ Bezugskosten', key: 'bezugskosten' },
   { label: '= Bezugspreis (BP)', key: 'bp' },
   { label: '+ Handlungskosten', key: 'handlungskosten', isPercentage: true },
   { label: '= Selbstkosten', key: 'selbstkosten' },
@@ -52,7 +51,7 @@ const RUECKWAERTS_SCHEMA: KalkulationStep[] = [
   { label: '= Selbstkosten', key: 'selbstkosten' },
   { label: '− Handlungskosten', key: 'handlungskosten', isPercentage: true },
   { label: '= Bezugspreis (BP)', key: 'bp' },
-  { label: '− Bezugskosten', key: 'bezugskosten', isResult: true },
+  { label: '− Bezugskosten', key: 'bezugskosten' },
   { label: '= Bareinkaufspreis (BEP)', key: 'bep' },
   { label: '+ Lieferskonto', key: 'skonto', isPercentage: true },
   { label: '= Zieleinkaufspreis (ZEP)', key: 'zep' },
@@ -656,11 +655,13 @@ function buildQuestion(
   };
 }
 
+/** Generates a dedicated Vorwärtskalkulation question with medium difficulty. */
 export function generateVorwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateVorwaertsCalculation();
   return buildQuestion('vorwaerts', given, calculated, schema, { moduleId: 'handelskalkulationVorwaerts' });
 }
 
+/** Generates a dedicated Rückwärtskalkulation question with hard difficulty. */
 export function generateRueckwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateRueckwaertsCalculation();
   return buildQuestion('rueckwaerts', given, calculated, schema, { moduleId: 'handelskalkulationRueckwaerts' });

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -153,7 +153,8 @@ function buildAnswerInputs(
     }));
 }
 
-/** Shared calculation chain — single source of truth for all kalkulation types. */
+/** Shared calculation chain for vorwaerts and rueckwaerts (forward/backward) kalkulation.
+ *  Differenz kalkulation reuses the forward chain but computes its own backward chain separately. */
 interface BaseKalkulationParams {
   lepBrutto: number;
   ustRate: number;
@@ -215,6 +216,8 @@ function computeKalkulationChain(params: BaseKalkulationParams): BaseKalkulation
 
 export function generateVorwaertsCalculation(): GeneratedKalkulation {
   const params = randomKalkulationParams();
+  const { lepBrutto, ustRate, lieferRabatt, lieferskonto, bezugskosten,
+    handlungsKosten, gewinnZuschlag, kundenSkonto, kundenRabatt } = params;
   const chain = computeKalkulationChain(params);
 
   const calculated = toRoundedRecord({
@@ -223,7 +226,7 @@ export function generateVorwaertsCalculation(): GeneratedKalkulation {
     zep: chain.rabattStep.remaining,
     skonto: chain.skontoStep.amount,
     bep: chain.skontoStep.remaining,
-    bezugskosten: params.bezugskosten,
+    bezugskosten,
     bp: chain.bp,
     handlungskosten: chain.handlungskostenStep.amount,
     selbstkosten: chain.handlungskostenStep.total,
@@ -238,15 +241,15 @@ export function generateVorwaertsCalculation(): GeneratedKalkulation {
   });
 
   const given: Record<string, number> = {
-    lepBrutto: round2(params.lepBrutto),
-    ustRate: params.ustRate,
-    lieferRabatt: params.lieferRabatt,
-    lieferskonto: params.lieferskonto,
-    bezugskosten: round2(params.bezugskosten),
-    handlungsKosten: params.handlungsKosten,
-    gewinnZuschlag: params.gewinnZuschlag,
-    kundenSkonto: params.kundenSkonto,
-    kundenRabatt: params.kundenRabatt,
+    lepBrutto: round2(lepBrutto),
+    ustRate,
+    lieferRabatt,
+    lieferskonto,
+    bezugskosten: round2(bezugskosten),
+    handlungsKosten,
+    gewinnZuschlag,
+    kundenSkonto,
+    kundenRabatt,
   };
 
   return { given, calculated, schema: VORWAERTS_SCHEMA };
@@ -254,6 +257,8 @@ export function generateVorwaertsCalculation(): GeneratedKalkulation {
 
 export function generateRueckwaertsCalculation(): GeneratedKalkulation {
   const params = randomKalkulationParams();
+  const { ustRate, lieferRabatt, lieferskonto, bezugskosten,
+    handlungsKosten, gewinnZuschlag, kundenSkonto, kundenRabatt } = params;
   const chain = computeKalkulationChain(params);
 
   const calculated = toRoundedRecord({
@@ -267,7 +272,7 @@ export function generateRueckwaertsCalculation(): GeneratedKalkulation {
     selbstkosten: chain.handlungskostenStep.total,
     handlungskosten: chain.handlungskostenStep.amount,
     bp: chain.bp,
-    bezugskosten: params.bezugskosten,
+    bezugskosten,
     bep: chain.skontoStep.remaining,
     skonto: chain.skontoStep.amount,
     zep: chain.rabattStep.remaining,
@@ -277,14 +282,14 @@ export function generateRueckwaertsCalculation(): GeneratedKalkulation {
 
   const given: Record<string, number> = {
     bruttovk: round2(chain.ustStep.total),
-    ustRate: params.ustRate,
-    kundenRabatt: params.kundenRabatt,
-    kundenSkonto: params.kundenSkonto,
-    gewinnZuschlag: params.gewinnZuschlag,
-    handlungsKosten: params.handlungsKosten,
-    bezugskosten: round2(params.bezugskosten),
-    lieferskonto: params.lieferskonto,
-    lieferRabatt: params.lieferRabatt,
+    ustRate,
+    kundenRabatt,
+    kundenSkonto,
+    gewinnZuschlag,
+    handlungsKosten,
+    bezugskosten: round2(bezugskosten),
+    lieferskonto,
+    lieferRabatt,
   };
 
   return { given, calculated, schema: RUECKWAERTS_SCHEMA };
@@ -567,7 +572,7 @@ function buildQuestion(
     solutionSteps.push(`Skonto = ${formatEuro(backwardSteps.zep)} − ${formatEuro(backwardSteps.bep)} = ${formatEuro(backwardSteps.skonto)}`);
     solutionSteps.push(`LEP netto = ${formatEuro(backwardSteps.zep)} / ${formatDiscountFactor(given.lieferRabatt)} = ${formatEuro(backwardSteps.lep)}`);
     solutionSteps.push(`Rabatt = ${formatEuro(backwardSteps.lep)} − ${formatEuro(backwardSteps.zep)} = ${formatEuro(backwardSteps.rabatt)}`);
-    solutionSteps.push(`LEP brutto = ${formatEuro(backwardSteps.lep)} × 1,19 = ${formatEuro(round2(backwardSteps.lep * 1.19))}`);
+    solutionSteps.push(`LEP brutto = ${formatEuro(backwardSteps.lep)} × 1,${given.ustRate} = ${formatEuro(round2(backwardSteps.lep * (1 + given.ustRate / 100)))}`);
     solutionSteps.push('');
 
     const differenz = calculated.differenz as number;
@@ -626,7 +631,7 @@ function buildQuestion(
       solutionSteps.push(`Skonto = ${formatEuro(calculated.zep as number)} − ${formatEuro(calculated.bep as number)} = ${formatEuro(calculated.skonto as number)}`);
       solutionSteps.push(`LEP netto = ${formatEuro(calculated.zep as number)} / ${formatDiscountFactor(given.lieferRabatt)} = ${formatEuro(calculated.lep as number)}`);
       solutionSteps.push(`Rabatt = ${formatEuro(calculated.lep as number)} − ${formatEuro(calculated.zep as number)} = ${formatEuro(calculated.rabatt as number)}`);
-      solutionSteps.push(`LEP brutto = ${formatEuro(calculated.lep as number)} × 1,19 = ${formatEuro(round2((calculated.lep as number) * 1.19))}`);
+      solutionSteps.push(`LEP brutto = ${formatEuro(calculated.lep as number)} × 1,${given.ustRate} = ${formatEuro(round2((calculated.lep as number) * (1 + given.ustRate / 100)))}`);
     }
   }
 
@@ -634,7 +639,7 @@ function buildQuestion(
     type === 'vorwaerts' ? 'medium' : 'hard';
 
   return {
-    id: `${moduleId ?? 'handelskalkulation'}-${Date.now()}`,
+    id: `${moduleId ?? 'handelskalkulation'}-${crypto.randomUUID().slice(0, 8)}`,
     theme: 'Wirtschaftsrechnen',
     module: moduleId ?? 'handelskalkulation',
     questionText: frage,
@@ -659,21 +664,22 @@ export function generateHandelskalkulationQuestion(): Question {
   const rand = Math.random();
   const type: KalkulationType = rand < 0.333 ? 'vorwaerts' : rand < 0.666 ? 'rueckwaerts' : 'differenz';
 
+  if (type === 'vorwaerts') {
+    const { given, calculated, schema } = generateVorwaertsCalculation();
+    return buildQuestion(type, given, calculated, schema);
+  }
+
+  if (type === 'rueckwaerts') {
+    const { given, calculated, schema } = generateRueckwaertsCalculation();
+    return buildQuestion(type, given, calculated, schema);
+  }
+
+  // DifferenzCalculation can fail to find valid values — wrap in try/catch and fallback
   try {
-    if (type === 'vorwaerts') {
-      const { given, calculated, schema } = generateVorwaertsCalculation();
-      return buildQuestion(type, given, calculated, schema);
-    }
-
-    if (type === 'rueckwaerts') {
-      const { given, calculated, schema } = generateRueckwaertsCalculation();
-      return buildQuestion(type, given, calculated, schema);
-    }
-
     const { given, calculated, forwardSteps, backwardSteps, schema } = generateDifferenzCalculation();
     return buildQuestion(type, given, calculated, schema, forwardSteps, backwardSteps);
   } catch {
-    // DifferenzCalculation can fail to find valid values — fallback to vorwaerts
+    console.warn('[handelskalkulation] DifferenzCalculation failed, falling back to vorwaerts');
     const { given, calculated, schema } = generateVorwaertsCalculation();
     return buildQuestion('vorwaerts', given, calculated, schema);
   }

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -635,13 +635,13 @@ function buildQuestion(
 export function generateVorwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateVorwaertsCalculation();
   const q = buildQuestion('vorwaerts', given, calculated, schema);
-  return { ...q, id: `handelskalkulation-vorwaerts-${Date.now()}`, module: 'handelskalkulation-vorwaerts' };
+  return { ...q, id: `handelskalkulationVorwaerts-${Date.now()}`, module: 'handelskalkulationVorwaerts' };
 }
 
 export function generateRueckwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateRueckwaertsCalculation();
   const q = buildQuestion('rueckwaerts', given, calculated, schema);
-  return { ...q, id: `handelskalkulation-rueckwaerts-${Date.now()}`, module: 'handelskalkulation-rueckwaerts' };
+  return { ...q, id: `handelskalkulationRueckwaerts-${Date.now()}`, module: 'handelskalkulationRueckwaerts' };
 }
 
 export function generateHandelskalkulationQuestion(): Question {

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -536,7 +536,7 @@ function buildQuestion(
     solutionSteps.push('=== VORWÄRTSKALKULATION (LEP → Brutto-VK) ===');
     solutionSteps.push(`Gegeben: LEP brutto = ${formatEuro(given.lepBrutto)}`);
     solutionSteps.push('');
-    solutionSteps.push(`LEP netto = ${formatEuro(given.lepBrutto)} / 1,19 = ${formatEuro(forwardSteps.lep)}`);
+    solutionSteps.push(`LEP netto = ${formatEuro(given.lepBrutto)} / 1,${given.ustRate} = ${formatEuro(forwardSteps.lep)}`);
     solutionSteps.push(`Rabatt = ${formatEuro(forwardSteps.lep)} × ${given.lieferRabatt}% = ${formatEuro(forwardSteps.rabatt)}`);
     solutionSteps.push(`ZEP = ${formatEuro(forwardSteps.lep)} − ${formatEuro(forwardSteps.rabatt)} = ${formatEuro(forwardSteps.zep)}`);
     solutionSteps.push(`Skonto = ${formatEuro(forwardSteps.zep)} × ${given.lieferskonto}% = ${formatEuro(forwardSteps.skonto)}`);
@@ -557,7 +557,7 @@ function buildQuestion(
     solutionSteps.push('=== RÜCKWÄRTSKALKULATION (Markt-Brutto-VK → LEP) ===');
     solutionSteps.push(`Gegeben: Markt-Brutto-VK = ${formatEuro(given.bruttovkMarkt)}`);
     solutionSteps.push('');
-    solutionSteps.push(`Netto-VK = ${formatEuro(given.bruttovkMarkt)} / 1,19 = ${formatEuro(backwardSteps.nettovk)}`);
+    solutionSteps.push(`Netto-VK = ${formatEuro(given.bruttovkMarkt)} / 1,${given.ustRate} = ${formatEuro(backwardSteps.nettovk)}`);
     solutionSteps.push(`USt = ${formatEuro(given.bruttovkMarkt)} − ${formatEuro(backwardSteps.nettovk)} = ${formatEuro(backwardSteps.ust)}`);
     solutionSteps.push(`Kundenrabatt = ${formatEuro(backwardSteps.nettovk)} × ${given.kundenRabatt}% = ${formatEuro(backwardSteps.kundenrabatt)}`);
     solutionSteps.push(`ZVP = ${formatEuro(backwardSteps.nettovk)} − ${formatEuro(backwardSteps.kundenrabatt)} = ${formatEuro(backwardSteps.zvp)}`);
@@ -597,7 +597,7 @@ function buildQuestion(
     if (type === 'vorwaerts') {
       solutionSteps.push(`Gegeben: LEP brutto = ${formatEuro(given.lepBrutto)}, Rabatt = ${given.lieferRabatt}%, Skonto = ${given.lieferskonto}%`);
       solutionSteps.push('');
-      solutionSteps.push(`LEP netto = ${formatEuro(given.lepBrutto)} / 1,19 = ${formatEuro(calculated.lep as number)}`);
+      solutionSteps.push(`LEP netto = ${formatEuro(given.lepBrutto)} / 1,${given.ustRate} = ${formatEuro(calculated.lep as number)}`);
       solutionSteps.push(`Rabatt = ${formatEuro(calculated.lep as number)} × ${given.lieferRabatt}% = ${formatEuro(calculated.rabatt as number)}`);
       solutionSteps.push(`ZEP = ${formatEuro(calculated.lep as number)} − ${formatEuro(calculated.rabatt as number)} = ${formatEuro(calculated.zep as number)}`);
       solutionSteps.push(`Skonto = ${formatEuro(calculated.zep as number)} × ${given.lieferskonto}% = ${formatEuro(calculated.skonto as number)}`);
@@ -616,7 +616,7 @@ function buildQuestion(
     } else {
       solutionSteps.push(`Gegeben: Brutto-VK = ${formatEuro(given.bruttovk)}, alle Zu- und Abschläge`);
       solutionSteps.push('');
-      solutionSteps.push(`Netto-VK = ${formatEuro(given.bruttovk)} / 1,19 = ${formatEuro(calculated.nettovk as number)}`);
+      solutionSteps.push(`Netto-VK = ${formatEuro(given.bruttovk)} / 1,${given.ustRate} = ${formatEuro(calculated.nettovk as number)}`);
       solutionSteps.push(`USt = ${formatEuro(given.bruttovk)} − ${formatEuro(calculated.nettovk as number)} = ${formatEuro(calculated.ust as number)}`);
       solutionSteps.push(`Kundenrabatt = ${formatEuro(calculated.nettovk as number)} × ${given.kundenRabatt}% = ${formatEuro(calculated.kundenrabatt as number)}`);
       solutionSteps.push(`ZVP = ${formatEuro(calculated.nettovk as number)} − ${formatEuro(calculated.kundenrabatt as number)} = ${formatEuro(calculated.zvp as number)}`);

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -634,12 +634,14 @@ function buildQuestion(
 
 export function generateVorwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateVorwaertsCalculation();
-  return buildQuestion('vorwaerts', given, calculated, schema);
+  const q = buildQuestion('vorwaerts', given, calculated, schema);
+  return { ...q, id: `handelskalkulation-vorwaerts-${Date.now()}`, module: 'handelskalkulation-vorwaerts' };
 }
 
 export function generateRueckwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateRueckwaertsCalculation();
-  return buildQuestion('rueckwaerts', given, calculated, schema);
+  const q = buildQuestion('rueckwaerts', given, calculated, schema);
+  return { ...q, id: `handelskalkulation-rueckwaerts-${Date.now()}`, module: 'handelskalkulation-rueckwaerts' };
 }
 
 export function generateHandelskalkulationQuestion(): Question {

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -167,7 +167,6 @@ interface BaseKalkulationParams {
 }
 
 interface BaseKalkulationChain {
-  params: BaseKalkulationParams;
   lepNettoStep: ReturnType<typeof reverseMarkup>;
   rabattStep: ReturnType<typeof applyDeduction>;
   skontoStep: ReturnType<typeof applyDeduction>;
@@ -208,8 +207,15 @@ function computeKalkulationChain(params: BaseKalkulationParams): BaseKalkulation
   const ustStep = applyMarkup(kundenrabattStep.base, ustRate);
 
   return {
-    params, lepNettoStep, rabattStep, skontoStep, bp,
-    handlungskostenStep, gewinnStep, kundenskontoStep, kundenrabattStep, ustStep,
+    lepNettoStep,
+    rabattStep,
+    skontoStep,
+    bp,
+    handlungskostenStep,
+    gewinnStep,
+    kundenskontoStep,
+    kundenrabattStep,
+    ustStep,
   };
 }
 

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -466,10 +466,13 @@ function buildQuestion(
   given: Record<string, number>,
   calculated: Record<string, number>,
   schema: KalkulationStep[],
-  forwardSteps?: Record<string, number>,
-  backwardSteps?: Record<string, number>,
-  moduleId?: string
+  options: {
+    forwardSteps?: Record<string, number>;
+    backwardSteps?: Record<string, number>;
+    moduleId?: string;
+  } = {}
 ): Question {
+  const { forwardSteps, backwardSteps, moduleId } = options;
   if (type === 'differenz' && (!forwardSteps || !backwardSteps)) {
     throw new Error('buildQuestion: forwardSteps and backwardSteps are required for differenz type');
   }
@@ -655,12 +658,12 @@ function buildQuestion(
 
 export function generateVorwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateVorwaertsCalculation();
-  return buildQuestion('vorwaerts', given, calculated, schema, undefined, undefined, 'handelskalkulationVorwaerts');
+  return buildQuestion('vorwaerts', given, calculated, schema, { moduleId: 'handelskalkulationVorwaerts' });
 }
 
 export function generateRueckwaertsKalkulationQuestion(): Question {
   const { given, calculated, schema } = generateRueckwaertsCalculation();
-  return buildQuestion('rueckwaerts', given, calculated, schema, undefined, undefined, 'handelskalkulationRueckwaerts');
+  return buildQuestion('rueckwaerts', given, calculated, schema, { moduleId: 'handelskalkulationRueckwaerts' });
 }
 
 export function generateHandelskalkulationQuestion(): Question {
@@ -680,7 +683,7 @@ export function generateHandelskalkulationQuestion(): Question {
   // DifferenzCalculation can fail to find valid values — wrap in try/catch and fallback
   try {
     const { given, calculated, forwardSteps, backwardSteps, schema } = generateDifferenzCalculation();
-    return buildQuestion(type, given, calculated, schema, forwardSteps, backwardSteps);
+    return buildQuestion(type, given, calculated, schema, { forwardSteps, backwardSteps });
   } catch (error) {
     console.warn('[handelskalkulation] DifferenzCalculation failed, falling back to vorwaerts', error);
     const { given, calculated, schema } = generateVorwaertsCalculation();

--- a/src/app/lib/generators/handelskalkulation.ts
+++ b/src/app/lib/generators/handelskalkulation.ts
@@ -539,7 +539,7 @@ function buildQuestion(
     solutionSteps.push('=== VORWÄRTSKALKULATION (LEP → Brutto-VK) ===');
     solutionSteps.push(`Gegeben: LEP brutto = ${formatEuro(given.lepBrutto)}`);
     solutionSteps.push('');
-    solutionSteps.push(`LEP netto = ${formatEuro(given.lepBrutto)} / 1,${given.ustRate} = ${formatEuro(forwardSteps.lep)}`);
+    solutionSteps.push(`LEP netto = ${formatEuro(given.lepBrutto)} / ${formatMarkupFactor(given.ustRate)} = ${formatEuro(forwardSteps.lep)}`);
     solutionSteps.push(`Rabatt = ${formatEuro(forwardSteps.lep)} × ${given.lieferRabatt}% = ${formatEuro(forwardSteps.rabatt)}`);
     solutionSteps.push(`ZEP = ${formatEuro(forwardSteps.lep)} − ${formatEuro(forwardSteps.rabatt)} = ${formatEuro(forwardSteps.zep)}`);
     solutionSteps.push(`Skonto = ${formatEuro(forwardSteps.zep)} × ${given.lieferskonto}% = ${formatEuro(forwardSteps.skonto)}`);
@@ -560,7 +560,7 @@ function buildQuestion(
     solutionSteps.push('=== RÜCKWÄRTSKALKULATION (Markt-Brutto-VK → LEP) ===');
     solutionSteps.push(`Gegeben: Markt-Brutto-VK = ${formatEuro(given.bruttovkMarkt)}`);
     solutionSteps.push('');
-    solutionSteps.push(`Netto-VK = ${formatEuro(given.bruttovkMarkt)} / 1,${given.ustRate} = ${formatEuro(backwardSteps.nettovk)}`);
+    solutionSteps.push(`Netto-VK = ${formatEuro(given.bruttovkMarkt)} / ${formatMarkupFactor(given.ustRate)} = ${formatEuro(backwardSteps.nettovk)}`);
     solutionSteps.push(`USt = ${formatEuro(given.bruttovkMarkt)} − ${formatEuro(backwardSteps.nettovk)} = ${formatEuro(backwardSteps.ust)}`);
     solutionSteps.push(`Kundenrabatt = ${formatEuro(backwardSteps.nettovk)} × ${given.kundenRabatt}% = ${formatEuro(backwardSteps.kundenrabatt)}`);
     solutionSteps.push(`ZVP = ${formatEuro(backwardSteps.nettovk)} − ${formatEuro(backwardSteps.kundenrabatt)} = ${formatEuro(backwardSteps.zvp)}`);
@@ -575,7 +575,7 @@ function buildQuestion(
     solutionSteps.push(`Skonto = ${formatEuro(backwardSteps.zep)} − ${formatEuro(backwardSteps.bep)} = ${formatEuro(backwardSteps.skonto)}`);
     solutionSteps.push(`LEP netto = ${formatEuro(backwardSteps.zep)} / ${formatDiscountFactor(given.lieferRabatt)} = ${formatEuro(backwardSteps.lep)}`);
     solutionSteps.push(`Rabatt = ${formatEuro(backwardSteps.lep)} − ${formatEuro(backwardSteps.zep)} = ${formatEuro(backwardSteps.rabatt)}`);
-    solutionSteps.push(`LEP brutto = ${formatEuro(backwardSteps.lep)} × 1,${given.ustRate} = ${formatEuro(round2(backwardSteps.lep * (1 + given.ustRate / 100)))}`);
+    solutionSteps.push(`LEP brutto = ${formatEuro(backwardSteps.lep)} × ${formatMarkupFactor(given.ustRate)} = ${formatEuro(round2(backwardSteps.lep * (1 + given.ustRate / 100)))}`);
     solutionSteps.push('');
 
     const differenz = calculated.differenz as number;
@@ -600,7 +600,7 @@ function buildQuestion(
     if (type === 'vorwaerts') {
       solutionSteps.push(`Gegeben: LEP brutto = ${formatEuro(given.lepBrutto)}, Rabatt = ${given.lieferRabatt}%, Skonto = ${given.lieferskonto}%`);
       solutionSteps.push('');
-      solutionSteps.push(`LEP netto = ${formatEuro(given.lepBrutto)} / 1,${given.ustRate} = ${formatEuro(calculated.lep as number)}`);
+      solutionSteps.push(`LEP netto = ${formatEuro(given.lepBrutto)} / ${formatMarkupFactor(given.ustRate)} = ${formatEuro(calculated.lep as number)}`);
       solutionSteps.push(`Rabatt = ${formatEuro(calculated.lep as number)} × ${given.lieferRabatt}% = ${formatEuro(calculated.rabatt as number)}`);
       solutionSteps.push(`ZEP = ${formatEuro(calculated.lep as number)} − ${formatEuro(calculated.rabatt as number)} = ${formatEuro(calculated.zep as number)}`);
       solutionSteps.push(`Skonto = ${formatEuro(calculated.zep as number)} × ${given.lieferskonto}% = ${formatEuro(calculated.skonto as number)}`);
@@ -619,7 +619,7 @@ function buildQuestion(
     } else {
       solutionSteps.push(`Gegeben: Brutto-VK = ${formatEuro(given.bruttovk)}, alle Zu- und Abschläge`);
       solutionSteps.push('');
-      solutionSteps.push(`Netto-VK = ${formatEuro(given.bruttovk)} / 1,${given.ustRate} = ${formatEuro(calculated.nettovk as number)}`);
+      solutionSteps.push(`Netto-VK = ${formatEuro(given.bruttovk)} / ${formatMarkupFactor(given.ustRate)} = ${formatEuro(calculated.nettovk as number)}`);
       solutionSteps.push(`USt = ${formatEuro(given.bruttovk)} − ${formatEuro(calculated.nettovk as number)} = ${formatEuro(calculated.ust as number)}`);
       solutionSteps.push(`Kundenrabatt = ${formatEuro(calculated.nettovk as number)} × ${given.kundenRabatt}% = ${formatEuro(calculated.kundenrabatt as number)}`);
       solutionSteps.push(`ZVP = ${formatEuro(calculated.nettovk as number)} − ${formatEuro(calculated.kundenrabatt as number)} = ${formatEuro(calculated.zvp as number)}`);
@@ -634,7 +634,7 @@ function buildQuestion(
       solutionSteps.push(`Skonto = ${formatEuro(calculated.zep as number)} − ${formatEuro(calculated.bep as number)} = ${formatEuro(calculated.skonto as number)}`);
       solutionSteps.push(`LEP netto = ${formatEuro(calculated.zep as number)} / ${formatDiscountFactor(given.lieferRabatt)} = ${formatEuro(calculated.lep as number)}`);
       solutionSteps.push(`Rabatt = ${formatEuro(calculated.lep as number)} − ${formatEuro(calculated.zep as number)} = ${formatEuro(calculated.rabatt as number)}`);
-      solutionSteps.push(`LEP brutto = ${formatEuro(calculated.lep as number)} × 1,${given.ustRate} = ${formatEuro(round2((calculated.lep as number) * (1 + given.ustRate / 100)))}`);
+      solutionSteps.push(`LEP brutto = ${formatEuro(calculated.lep as number)} × ${formatMarkupFactor(given.ustRate)} = ${formatEuro(round2((calculated.lep as number) * (1 + given.ustRate / 100)))}`);
     }
   }
 
@@ -681,8 +681,8 @@ export function generateHandelskalkulationQuestion(): Question {
   try {
     const { given, calculated, forwardSteps, backwardSteps, schema } = generateDifferenzCalculation();
     return buildQuestion(type, given, calculated, schema, forwardSteps, backwardSteps);
-  } catch {
-    console.warn('[handelskalkulation] DifferenzCalculation failed, falling back to vorwaerts');
+  } catch (error) {
+    console.warn('[handelskalkulation] DifferenzCalculation failed, falling back to vorwaerts', error);
     const { given, calculated, schema } = generateVorwaertsCalculation();
     return buildQuestion('vorwaerts', given, calculated, schema);
   }

--- a/src/app/lib/moduleIds.ts
+++ b/src/app/lib/moduleIds.ts
@@ -13,7 +13,6 @@ const CANONICAL_TO_STORED_MODULE_ID: Record<string, string> = {
   imageTransferCombo: 'image-transfer-combo',
   handelskalkulationVorwaerts: 'handelskalkulation-vorwaerts',
   handelskalkulationRueckwaerts: 'handelskalkulation-rueckwaerts',
-  handelskalkulation: 'handelskalkulation-vorwaerts',
 };
 
 export interface ProgressLike {

--- a/src/app/lib/moduleIds.ts
+++ b/src/app/lib/moduleIds.ts
@@ -57,11 +57,18 @@ export function normalizeProgressModules<T extends ProgressLike>(
       );
     }
 
-    if (
-      row.last_session &&
-      (!existing.last_session || row.last_session > existing.last_session)
-    ) {
-      existing.last_session = row.last_session;
+    if (row.last_session) {
+      const rowTimestamp = Date.parse(row.last_session);
+      const existingTimestamp = existing.last_session
+        ? Date.parse(existing.last_session)
+        : Number.NEGATIVE_INFINITY;
+
+      if (
+        !Number.isNaN(rowTimestamp) &&
+        (Number.isNaN(existingTimestamp) || rowTimestamp > existingTimestamp)
+      ) {
+        existing.last_session = row.last_session;
+      }
     }
   }
 

--- a/src/app/lib/moduleIds.ts
+++ b/src/app/lib/moduleIds.ts
@@ -1,18 +1,17 @@
 const LEGACY_TO_CANONICAL_MODULE_ID: Record<string, string> = {
-  'image-calc': 'imageCalc',
-  'unit-conversion': 'unitConversion',
-  'image-transfer-combo': 'imageTransferCombo',
-  'handelskalkulation-vorwaerts': 'handelskalkulationVorwaerts',
-  'handelskalkulation-rueckwaerts': 'handelskalkulationRueckwaerts',
-  handelskalkulation: 'handelskalkulationVorwaerts',
+  "image-calc": "imageCalc",
+  "unit-conversion": "unitConversion",
+  "image-transfer-combo": "imageTransferCombo",
+  "handelskalkulation-vorwaerts": "handelskalkulationVorwaerts",
+  "handelskalkulation-rueckwaerts": "handelskalkulationRueckwaerts",
 };
 
 const CANONICAL_TO_STORED_MODULE_ID: Record<string, string> = {
-  imageCalc: 'image-calc',
-  unitConversion: 'unit-conversion',
-  imageTransferCombo: 'image-transfer-combo',
-  handelskalkulationVorwaerts: 'handelskalkulation-vorwaerts',
-  handelskalkulationRueckwaerts: 'handelskalkulation-rueckwaerts',
+  imageCalc: "image-calc",
+  unitConversion: "unit-conversion",
+  imageTransferCombo: "image-transfer-combo",
+  handelskalkulationVorwaerts: "handelskalkulation-vorwaerts",
+  handelskalkulationRueckwaerts: "handelskalkulation-rueckwaerts",
 };
 
 export interface ProgressLike {
@@ -31,7 +30,9 @@ export function toStoredProgressModuleId(moduleId: string): string {
   return CANONICAL_TO_STORED_MODULE_ID[moduleId] ?? moduleId;
 }
 
-export function normalizeProgressModules<T extends ProgressLike>(rows: T[]): T[] {
+export function normalizeProgressModules<T extends ProgressLike>(
+  rows: T[],
+): T[] {
   const merged = new Map<string, T>();
 
   for (const row of rows) {
@@ -49,11 +50,17 @@ export function normalizeProgressModules<T extends ProgressLike>(rows: T[]): T[]
     existing.questions_attempted += row.questions_attempted;
     existing.questions_correct += row.questions_correct;
 
-    if (typeof row.streak_days === 'number') {
-      existing.streak_days = Math.max(existing.streak_days ?? 0, row.streak_days);
+    if (typeof row.streak_days === "number") {
+      existing.streak_days = Math.max(
+        existing.streak_days ?? 0,
+        row.streak_days,
+      );
     }
 
-    if (row.last_session && (!existing.last_session || row.last_session > existing.last_session)) {
+    if (
+      row.last_session &&
+      (!existing.last_session || row.last_session > existing.last_session)
+    ) {
       existing.last_session = row.last_session;
     }
   }

--- a/src/app/lib/moduleIds.ts
+++ b/src/app/lib/moduleIds.ts
@@ -10,6 +10,8 @@ const CANONICAL_TO_STORED_MODULE_ID: Record<string, string> = {
   imageCalc: 'image-calc',
   unitConversion: 'unit-conversion',
   imageTransferCombo: 'image-transfer-combo',
+  handelskalkulationVorwaerts: 'handelskalkulation-vorwaerts',
+  handelskalkulationRueckwaerts: 'handelskalkulation-rueckwaerts',
 };
 
 export interface ProgressLike {

--- a/src/app/lib/moduleIds.ts
+++ b/src/app/lib/moduleIds.ts
@@ -4,6 +4,7 @@ const LEGACY_TO_CANONICAL_MODULE_ID: Record<string, string> = {
   'image-transfer-combo': 'imageTransferCombo',
   'handelskalkulation-vorwaerts': 'handelskalkulationVorwaerts',
   'handelskalkulation-rueckwaerts': 'handelskalkulationRueckwaerts',
+  handelskalkulation: 'handelskalkulationVorwaerts',
 };
 
 const CANONICAL_TO_STORED_MODULE_ID: Record<string, string> = {

--- a/src/app/lib/moduleIds.ts
+++ b/src/app/lib/moduleIds.ts
@@ -2,6 +2,8 @@ const LEGACY_TO_CANONICAL_MODULE_ID: Record<string, string> = {
   'image-calc': 'imageCalc',
   'unit-conversion': 'unitConversion',
   'image-transfer-combo': 'imageTransferCombo',
+  'handelskalkulation-vorwaerts': 'handelskalkulationVorwaerts',
+  'handelskalkulation-rueckwaerts': 'handelskalkulationRueckwaerts',
 };
 
 const CANONICAL_TO_STORED_MODULE_ID: Record<string, string> = {

--- a/src/app/lib/moduleIds.ts
+++ b/src/app/lib/moduleIds.ts
@@ -13,6 +13,7 @@ const CANONICAL_TO_STORED_MODULE_ID: Record<string, string> = {
   imageTransferCombo: 'image-transfer-combo',
   handelskalkulationVorwaerts: 'handelskalkulation-vorwaerts',
   handelskalkulationRueckwaerts: 'handelskalkulation-rueckwaerts',
+  handelskalkulation: 'handelskalkulation-vorwaerts',
 };
 
 export interface ProgressLike {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -203,29 +203,11 @@ const GENERATORS: Record<string, () => Question> = {
   },
   'handelskalkulation-vorwaerts': () => {
     const q = generateVorwaertsKalkulationQuestion();
-    return {
-      id: `handelskalkulation-vorwaerts-${Date.now()}`,
-      theme: q.theme,
-      module: 'handelskalkulation-vorwaerts',
-      questionText: q.questionText,
-      expectedAnswers: q.expectedAnswers,
-      solutionSteps: q.solutionSteps,
-      difficulty: q.difficulty,
-      answerInputs: q.answerInputs,
-    };
+    return { ...q, id: `handelskalkulation-vorwaerts-${Date.now()}` };
   },
   'handelskalkulation-rueckwaerts': () => {
     const q = generateRueckwaertsKalkulationQuestion();
-    return {
-      id: `handelskalkulation-rueckwaerts-${Date.now()}`,
-      theme: q.theme,
-      module: 'handelskalkulation-rueckwaerts',
-      questionText: q.questionText,
-      expectedAnswers: q.expectedAnswers,
-      solutionSteps: q.solutionSteps,
-      difficulty: q.difficulty,
-      answerInputs: q.answerInputs,
-    };
+    return { ...q, id: `handelskalkulation-rueckwaerts-${Date.now()}` };
   },
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,7 @@ import { generateOsiQuestion } from './lib/generators/osi';
 import { generateCableQuestion, CABLE_TYPES, ALL_CABLE_PROS } from './lib/generators/cables';
 import { generateLinuxQuestion } from './lib/generators/linux';
 import { generateCloudQuestion } from './lib/generators/cloud';
-import { generateHandelskalkulationQuestion } from './lib/generators/handelskalkulation';
+import { generateHandelskalkulationQuestion, generateVorwaertsKalkulationQuestion, generateRueckwaertsKalkulationQuestion } from './lib/generators/handelskalkulation';
 
 const GENERATORS: Record<string, () => Question> = {
   bandwidth: generateBandwidthQuestion,
@@ -200,7 +200,33 @@ const GENERATORS: Record<string, () => Question> = {
       difficulty: q.difficulty,
       answerInputs: q.answerInputs,
     };
-  }
+  },
+  'handelskalkulation-vorwaerts': () => {
+    const q = generateVorwaertsKalkulationQuestion();
+    return {
+      id: `handelskalkulation-vorwaerts-${Date.now()}`,
+      theme: q.theme,
+      module: 'handelskalkulation-vorwaerts',
+      questionText: q.questionText,
+      expectedAnswers: q.expectedAnswers,
+      solutionSteps: q.solutionSteps,
+      difficulty: q.difficulty,
+      answerInputs: q.answerInputs,
+    };
+  },
+  'handelskalkulation-rueckwaerts': () => {
+    const q = generateRueckwaertsKalkulationQuestion();
+    return {
+      id: `handelskalkulation-rueckwaerts-${Date.now()}`,
+      theme: q.theme,
+      module: 'handelskalkulation-rueckwaerts',
+      questionText: q.questionText,
+      expectedAnswers: q.expectedAnswers,
+      solutionSteps: q.solutionSteps,
+      difficulty: q.difficulty,
+      answerInputs: q.answerInputs,
+    };
+  },
 };
 
 export default function Home() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import {
   updateProgress
 } from './lib/auth';
 import { validateQuestionAnswers } from './lib/answerValidation';
-import { normalizeProgressModules, toCanonicalModuleId } from './lib/moduleIds';
+import { toCanonicalModuleId } from './lib/moduleIds';
 
 // Import all generators
 import { generateBandwidthQuestion } from './lib/generators/bandwidth';
@@ -206,11 +206,10 @@ export default function Home() {
   const loadProgress = useCallback(async (hash: string) => {
     try {
       const userProgress: { module: string; questions_attempted: number; questions_correct: number; streak_days?: number | null }[] = await getAllProgress(hash);
-      const normalizedProgress = normalizeProgressModules(userProgress);
-      setProgress(normalizedProgress);
+      setProgress(userProgress);
       
       // Calculate streak (simplified)
-      const maxStreak = Math.max(0, ...normalizedProgress.map(p => p.streak_days ?? 0));
+      const maxStreak = Math.max(0, ...userProgress.map(p => p.streak_days ?? 0));
       setStreakDays(maxStreak);
     } catch (error) {
       console.error('Error loading progress:', error);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import {
   updateProgress
 } from './lib/auth';
 import { validateQuestionAnswers } from './lib/answerValidation';
-import { toCanonicalModuleId } from './lib/moduleIds';
+import { normalizeProgressModules, toCanonicalModuleId } from './lib/moduleIds';
 
 // Import all generators
 import { generateBandwidthQuestion } from './lib/generators/bandwidth';
@@ -188,19 +188,7 @@ const GENERATORS: Record<string, () => Question> = {
       scenario: q.scenario,
     };
   },
-  handelskalkulation: () => {
-    const q = generateHandelskalkulationQuestion();
-    return {
-      id: `handelskalkulation-${Date.now()}`,
-      theme: q.theme,
-      module: 'handelskalkulation',
-      questionText: q.questionText,
-      expectedAnswers: q.expectedAnswers,
-      solutionSteps: q.solutionSteps,
-      difficulty: q.difficulty,
-      answerInputs: q.answerInputs,
-    };
-  },
+  handelskalkulation: generateHandelskalkulationQuestion,
   handelskalkulationVorwaerts: generateVorwaertsKalkulationQuestion,
   handelskalkulationRueckwaerts: generateRueckwaertsKalkulationQuestion,
 };
@@ -218,10 +206,11 @@ export default function Home() {
   const loadProgress = useCallback(async (hash: string) => {
     try {
       const userProgress: { module: string; questions_attempted: number; questions_correct: number; streak_days?: number | null }[] = await getAllProgress(hash);
-      setProgress(userProgress);
+      const normalizedProgress = normalizeProgressModules(userProgress);
+      setProgress(normalizedProgress);
       
       // Calculate streak (simplified)
-      const maxStreak = Math.max(0, ...userProgress.map(p => p.streak_days ?? 0));
+      const maxStreak = Math.max(0, ...normalizedProgress.map(p => p.streak_days ?? 0));
       setStreakDays(maxStreak);
     } catch (error) {
       console.error('Error loading progress:', error);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,10 @@ import { generateLinuxQuestion } from './lib/generators/linux';
 import { generateCloudQuestion } from './lib/generators/cloud';
 import { generateHandelskalkulationQuestion, generateVorwaertsKalkulationQuestion, generateRueckwaertsKalkulationQuestion } from './lib/generators/handelskalkulation';
 
+function createQuestionId(module: string): string {
+  return `${module}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
 const GENERATORS: Record<string, () => Question> = {
   bandwidth: generateBandwidthQuestion,
   imageCalc: generateImageCalcQuestion,
@@ -47,7 +51,7 @@ const GENERATORS: Record<string, () => Question> = {
   binary: () => {
     const q = generateBinaryQuestion();
     return {
-      id: `binary-${Date.now()}`,
+      id: createQuestionId('binary'),
       theme: q.theme,
       module: 'binary',
       questionText: q.questionText,
@@ -59,7 +63,7 @@ const GENERATORS: Record<string, () => Question> = {
   hexBinary: () => {
     const q = generateHexBinaryQuestion();
     return {
-      id: `hexBinary-${Date.now()}`,
+      id: createQuestionId('hexBinary'),
       theme: q.theme,
       module: 'hexBinary',
       questionText: q.questionText,
@@ -71,7 +75,7 @@ const GENERATORS: Record<string, () => Question> = {
   hex: () => {
     const q = generateHexQuestion();
     return {
-      id: `hex-${Date.now()}`,
+      id: createQuestionId('hex'),
       theme: q.theme,
       module: 'hex',
       questionText: q.questionText,
@@ -83,7 +87,7 @@ const GENERATORS: Record<string, () => Question> = {
   subnetMask: () => {
     const q = generateSubnetMaskQuestion();
     return {
-      id: `subnetMask-${Date.now()}`,
+      id: createQuestionId('subnetMask'),
       theme: q.theme,
       module: 'subnetMask',
       questionText: q.questionText,
@@ -95,7 +99,7 @@ const GENERATORS: Record<string, () => Question> = {
   aggregation: () => {
     const q = generateAggregationQuestion();
     return {
-      id: `aggregation-${Date.now()}`,
+      id: createQuestionId('aggregation'),
       theme: q.theme,
       module: 'aggregation',
       questionText: q.questionText,
@@ -107,7 +111,7 @@ const GENERATORS: Record<string, () => Question> = {
   ports: () => {
     const q = generatePortQuestion();
     return {
-      id: `ports-${Date.now()}`,
+      id: createQuestionId('ports'),
       theme: q.theme,
       module: 'ports',
       questionText: q.questionText,
@@ -120,7 +124,7 @@ const GENERATORS: Record<string, () => Question> = {
   osi: () => {
     const q = generateOsiQuestion();
     return {
-      id: `osi-${Date.now()}`,
+      id: createQuestionId('osi'),
       theme: q.theme,
       module: 'osi',
       questionText: q.questionText,
@@ -142,7 +146,7 @@ const GENERATORS: Record<string, () => Question> = {
     }));
 
     return {
-      id: `cables-${Date.now()}`,
+      id: createQuestionId('cables'),
       theme: q.theme,
       module: 'cables',
       questionText: q.questionText,
@@ -163,7 +167,7 @@ const GENERATORS: Record<string, () => Question> = {
   linux: () => {
     const q = generateLinuxQuestion();
     return {
-      id: `linux-${Date.now()}`,
+      id: createQuestionId('linux'),
       theme: q.theme,
       module: 'linux',
       questionText: q.questionText,
@@ -177,7 +181,7 @@ const GENERATORS: Record<string, () => Question> = {
   cloud: () => {
     const q = generateCloudQuestion();
     return {
-      id: `cloud-${Date.now()}`,
+      id: createQuestionId('cloud'),
       theme: q.theme,
       module: 'cloud',
       questionText: q.questionText,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -201,14 +201,8 @@ const GENERATORS: Record<string, () => Question> = {
       answerInputs: q.answerInputs,
     };
   },
-  'handelskalkulation-vorwaerts': () => {
-    const q = generateVorwaertsKalkulationQuestion();
-    return { ...q, id: `handelskalkulation-vorwaerts-${Date.now()}` };
-  },
-  'handelskalkulation-rueckwaerts': () => {
-    const q = generateRueckwaertsKalkulationQuestion();
-    return { ...q, id: `handelskalkulation-rueckwaerts-${Date.now()}` };
-  },
+  handelskalkulationVorwaerts: generateVorwaertsKalkulationQuestion,
+  handelskalkulationRueckwaerts: generateRueckwaertsKalkulationQuestion,
 };
 
 export default function Home() {


### PR DESCRIPTION
This changeset separates Handelskalkulation into explicit Vorwärts- and Rückwärtskalkulation modules and aligns them with the app’s canonical module-id model. It also closes the gaps that made the split fragile: incorrect module identity, incomplete progress mappings, and missing regression coverage.

- **Module split**
  - Replace the single UI entry with two explicit modules:
    - `handelskalkulationVorwaerts` — LEP → Brutto-VK
    - `handelskalkulationRueckwaerts` — Brutto-VK → LEP
  - Keep the legacy combined `handelskalkulation` generator available for existing progress/practice-mistakes flows.

- **Canonical module identity**
  - Move the new modules to camelCase IDs to match the rest of the app.
  - Parameterize question construction so generated questions emit the correct `module` and ID prefix instead of inheriting `handelskalkulation`.

- **Progress/storage compatibility**
  - Add legacy → canonical normalization for the initial kebab-case split IDs.
  - Add canonical → stored mappings so persisted progress remains stable across old and new IDs.

- **Generator robustness**
  - Add a guarded fallback when differenz generation cannot find valid values.
  - Remove remaining hardcoded `1,19` strings from solution steps and derive VAT factors from `ustRate`.

- **Tests**
  - Add coverage for the new Vorwärts/Rückwärts generators:
    - module identity
    - ID prefix format
    - direction-specific answer inputs
    - no accidental `differenz` crossover
  - Update module-id compatibility tests and ThemeSelector expectations for the expanded module set.

```ts
const LEGACY_TO_CANONICAL_MODULE_ID = {
  'handelskalkulation-vorwaerts': 'handelskalkulationVorwaerts',
  'handelskalkulation-rueckwaerts': 'handelskalkulationRueckwaerts',
};

export function generateVorwaertsKalkulationQuestion(): Question {
  const { given, calculated, schema } = generateVorwaertsCalculation();
  return buildQuestion(
    'vorwaerts',
    given,
    calculated,
    schema,
    undefined,
    undefined,
    'handelskalkulationVorwaerts'
  );
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split "Kalkulation" into two selectable modules: "Vorwärtskalk." (LEP → Brutto‑VK) and "Rückwärtskalk." (Brutto‑VK → LEP); both appear in the selector on mobile and desktop.

* **Refactor**
  * Unified calculation pipeline, dynamic VAT/markup formatting, and more consistent solution step text and question IDs.

* **Tests**
  * Expanded test coverage for both modules, selector UI, and ID compatibility.

* **Chores**
  * Improved module ID compatibility and progress-entry merging logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->