### PR TITLE
types: tighten module ids to literal union

### DIFF
--- a/src/app/components/ProgressDashboard.tsx
+++ b/src/app/components/ProgressDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { toCanonicalModuleId } from '../lib/moduleIds';
-import { MODULE_NAMES } from '../lib/modules';
+import { MODULE_NAMES, isModuleId } from '../lib/modules';
 import { motion } from 'framer-motion';
 import { 
   Trophy, 
@@ -171,7 +171,7 @@ export default function ProgressDashboard({
                       <XCircle className="w-4 h-4 text-rose-400" />
                     )}
                     <span className="text-sm text-slate-300">
-                      {MODULE_NAMES[canonicalModuleId] || p.module}
+                      {isModuleId(canonicalModuleId) ? MODULE_NAMES[canonicalModuleId] : p.module}
                     </span>
                   </div>
                   <div className="flex items-center gap-4 text-sm">

--- a/src/app/lib/__tests__/modules.test.ts
+++ b/src/app/lib/__tests__/modules.test.ts
@@ -31,8 +31,11 @@ describe('modules registry', () => {
 
   it('SQL is the only auth-gated module and has a unique id', () => {
     expect(SQL_MODULE.id).toBe('sql');
-    const baseIds = new Set(BASE_MODULES.map((m) => m.id));
-    expect(baseIds.has('sql')).toBe(false);
+    // The 'sql' literal is provably absent from BASE_MODULES' id union
+    // (`(typeof BASE_MODULES)[number]['id']` excludes it). The cast is a
+    // defense-in-depth runtime check in case a future refactor widens
+    // the type without re-checking the auth-gating invariant.
+    expect(BASE_MODULES.some((m) => (m.id as string) === 'sql')).toBe(false);
   });
 
   it('ALL_MODULES is BASE_MODULES plus SQL_MODULE', () => {

--- a/src/app/lib/generators/__tests__/registry.test.ts
+++ b/src/app/lib/generators/__tests__/registry.test.ts
@@ -4,13 +4,19 @@ import { BASE_MODULES } from '../../modules';
 
 describe('generators registry', () => {
   it('every non-SQL base module has a registered generator', () => {
+    // Coverage is also enforced at compile time by
+    // `Record<RegistryModuleId, () => Question>`; this runtime check
+    // catches any future widening of that type.
     for (const m of BASE_MODULES) {
       expect(GENERATORS[m.id], `missing generator for ${m.id}`).toBeDefined();
     }
   });
 
   it('SQL module is intentionally absent from the registry (handled separately)', () => {
-    expect(GENERATORS['sql']).toBeUndefined();
+    // The `Record<RegistryModuleId, …>` type provably excludes 'sql' from
+    // the key space, so `GENERATORS['sql']` won't compile. The cast is
+    // for the runtime sanity check only — guards against future widening.
+    expect((GENERATORS as Record<string, unknown>)['sql']).toBeUndefined();
   });
 
   it('every generator is a function', () => {
@@ -19,11 +25,13 @@ describe('generators registry', () => {
     }
   });
 
-  it('spot-check: sample generators produce a valid Question with the right module id', () => {
-    // Sample a small set of representatives; full per-generator shape
-    // assertions live next to the generator (see generators/__tests__/).
-    const spotCheck = ['subnetting', 'unitConversion', 'binary', 'ports'];
-    for (const id of spotCheck) {
+  it('every registered generator produces a valid Question with the right module id', () => {
+    // Per-module test files in `generators/__tests__/` cover generator-
+    // specific shape (e.g. the cloud scenario field, the cables reasonCount
+    // builder). This loop is the safety net for the registry: it ensures
+    // every wrapper carries id + module + questionText + expectedAnswers
+    // + solutionSteps, and that the module field matches the key.
+    for (const id of GENERATOR_MODULE_IDS) {
       const q = GENERATORS[id]();
       expect(q.module, `${id} should set module to its own id`).toBe(id);
       expect(q.id, `${id} should have a non-empty id`).toBeTruthy();

--- a/src/app/lib/generators/registry.ts
+++ b/src/app/lib/generators/registry.ts
@@ -1,4 +1,5 @@
 import { Question } from '../../types';
+import { type ModuleId } from '../modules';
 import { generateBandwidthQuestion } from './bandwidth';
 import { generateImageCalcQuestion } from './imageCalc';
 import { generateImageTransferComboQuestion } from './imageTransferCombo';
@@ -22,12 +23,20 @@ import {
 } from './handelskalkulation';
 
 /**
+ * Module IDs that have a registered generator. Excludes `'sql'` because
+ * the SQL module's exercises come from an AI server action, not a local
+ * generator. Deriving this from `ModuleId` (instead of hardcoding the
+ * 18 keys) means a missing generator becomes a compile error.
+ */
+export type RegistryModuleId = Exclude<ModuleId, 'sql'>;
+
+/**
  * Generate a unique question id with a stable module prefix.
  * The prefix lets tests assert on the id namespace and keeps logs grep-able.
  * Falls back to a timestamp + random suffix when `crypto.randomUUID` is
  * unavailable (older browsers, jsdom).
  */
-export function createQuestionId(module: string): string {
+export function createQuestionId(module: ModuleId): string {
   const uniqueId =
     globalThis.crypto?.randomUUID?.() ??
     `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -45,8 +54,12 @@ export function createQuestionId(module: string): string {
  * stamp a fresh id + module name live here so the underlying generators
  * stay pure: they return typed content, this layer adapts it to a
  * `Question` ready for the `StudyCard` component.
+ *
+ * The `Record<RegistryModuleId, …>` type forces every base module to
+ * have a generator and forbids stray keys — `tsc` is the source of
+ * truth for coverage.
  */
-export const GENERATORS: Record<string, () => Question> = {
+export const GENERATORS: Record<RegistryModuleId, () => Question> = {
   bandwidth: generateBandwidthQuestion,
   imageCalc: generateImageCalcQuestion,
   imageTransferCombo: generateImageTransferComboQuestion,
@@ -199,5 +212,11 @@ export const GENERATORS: Record<string, () => Question> = {
   handelskalkulationRueckwaerts: generateRueckwaertsKalkulationQuestion,
 };
 
-/** Every module ID that has a registered generator. Use to assert coverage. */
-export const GENERATOR_MODULE_IDS: readonly string[] = Object.keys(GENERATORS);
+/**
+ * Every module ID that has a registered generator. Useful for tests and
+ * for asserting coverage from the module list. Derived from the keyof the
+ * registry so it stays in sync with `Record<RegistryModuleId, …>`.
+ */
+export const GENERATOR_MODULE_IDS: readonly RegistryModuleId[] = Object.keys(
+  GENERATORS,
+) as readonly RegistryModuleId[];

--- a/src/app/lib/modules.ts
+++ b/src/app/lib/modules.ts
@@ -48,8 +48,13 @@ export interface ModuleDescriptor {
  * register it in `lib/generators/registry.ts`, (3) ensure DB rows use the
  * canonical id (or add a mapping in `lib/moduleIds.ts` for legacy stored
  * forms).
+ *
+ * `as const satisfies readonly ModuleDescriptor[]` preserves the literal
+ * id type (e.g. `'bandwidth'`) instead of widening to `string`. That lets
+ * `ModuleId` (below) be a precise union and gives the registry
+ * compile-time exhaustiveness.
  */
-export const BASE_MODULES: readonly ModuleDescriptor[] = [
+export const BASE_MODULES = [
   { id: 'bandwidth', name: 'Übertragungszeit', icon: ArrowLeftRight, description: 'Dateitransfer' },
   { id: 'imageCalc', name: 'Bildgröße', icon: ImageIcon, description: 'Speicher' },
   { id: 'imageTransferCombo', name: 'Bild-Transfer', icon: ImageIcon, description: 'Bild + Übertragung' },
@@ -69,7 +74,7 @@ export const BASE_MODULES: readonly ModuleDescriptor[] = [
   { id: 'handelskalkulation', name: 'Kalkulation', icon: Calculator, description: 'Gemischt' },
   { id: 'handelskalkulationVorwaerts', name: 'Vorwärtskalkulation', shortName: 'Vorwärtskalk.', icon: Calculator, description: 'LEP → Brutto-VK' },
   { id: 'handelskalkulationRueckwaerts', name: 'Rückwärtskalkulation', shortName: 'Rückwärtskalk.', icon: Calculator, description: 'Brutto-VK → LEP' },
-] as const;
+] as const satisfies readonly ModuleDescriptor[];
 
 /**
  * The SQL module requires authentication. The component layer adds it
@@ -77,27 +82,48 @@ export const BASE_MODULES: readonly ModuleDescriptor[] = [
  * has no entry in `lib/generators/registry.ts` — its exercises come
  * from an AI server action (`actions/generate-sql-exercise.ts`).
  */
-export const SQL_MODULE: ModuleDescriptor = {
+export const SQL_MODULE = {
   id: 'sql',
   name: 'SQL',
   icon: Database,
   description: 'Datenbankabfragen',
-};
+} as const satisfies ModuleDescriptor;
 
 /** Every module, including auth-gated ones. Derived from BASE_MODULES + SQL_MODULE. */
-export const ALL_MODULES: readonly ModuleDescriptor[] = [...BASE_MODULES, SQL_MODULE];
+export const ALL_MODULES = [
+  ...BASE_MODULES,
+  SQL_MODULE,
+] as const satisfies readonly ModuleDescriptor[];
+
+/**
+ * Literal union of every module id. Derived from `ALL_MODULES` so adding a
+ * module to `BASE_MODULES` (or `SQL_MODULE`) automatically extends the
+ * union — and TypeScript then forces `MODULE_NAMES` / `MODULE_DESCRIPTIONS`
+ * / `MODULE_ICONS` and the `GENERATORS` registry to stay in sync.
+ */
+export type ModuleId = (typeof ALL_MODULES)[number]['id'];
 
 /** Quick lookup: id → German name. Use this anywhere a label is needed. */
-export const MODULE_NAMES: Record<string, string> = Object.fromEntries(
+export const MODULE_NAMES: Record<ModuleId, string> = Object.fromEntries(
   ALL_MODULES.map((m) => [m.id, m.name]),
-);
+) as Record<ModuleId, string>;
 
 /** Quick lookup: id → description. */
-export const MODULE_DESCRIPTIONS: Record<string, string> = Object.fromEntries(
+export const MODULE_DESCRIPTIONS: Record<ModuleId, string> = Object.fromEntries(
   ALL_MODULES.map((m) => [m.id, m.description]),
-);
+) as Record<ModuleId, string>;
 
 /** Quick lookup: id → Lucide icon component. */
-export const MODULE_ICONS: Record<string, LucideIcon> = Object.fromEntries(
+export const MODULE_ICONS: Record<ModuleId, LucideIcon> = Object.fromEntries(
   ALL_MODULES.map((m) => [m.id, m.icon]),
-);
+) as Record<ModuleId, LucideIcon>;
+
+/**
+ * Type guard: returns true when `value` is a registered module id.
+ * Use at boundaries (URL params, DB rows, RPC payloads) before indexing
+ * into `MODULE_NAMES` / `MODULE_DESCRIPTIONS` / `MODULE_ICONS` /
+ * `GENERATORS` so the rest of the code can rely on `ModuleId` narrowing.
+ */
+export function isModuleId(value: string): value is ModuleId {
+  return value in MODULE_NAMES;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import {
 } from './lib/auth';
 import { validateQuestionAnswers } from './lib/answerValidation';
 import { toCanonicalModuleId } from './lib/moduleIds';
+import { isModuleId } from './lib/modules';
 import { GENERATORS } from './lib/generators/registry';
 
 export default function Home() {
@@ -128,11 +129,11 @@ export default function Home() {
   };
 
   const generateNewQuestion = (module: string) => {
-    const generator = GENERATORS[module];
-    if (generator) {
-      const question = generator();
-      setCurrentQuestion(question);
-    }
+    // isModuleId narrows `module` to ModuleId; the SQL exclusion keeps us
+    // out of the registry (SQL has its own trainer + AI server action).
+    if (!isModuleId(module) || module === 'sql') return;
+    const question = GENERATORS[module]();
+    setCurrentQuestion(question);
   };
 
   const handleCheckAnswer = useCallback((answers: Record<string, string>): boolean => {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request introduces compile-time type safety for module identifiers across the application, replacing previously loose `string` typings that allowed typos and missing entries to slip through. The change is purely structural—runtime behavior is identical—but enforces consistency between the module list, generator registry, and progress lookups at the TypeScript level.

## What's Changing and Why

### New Centralized Module Definitions (`src/app/lib/modules.ts`)

A new module registry consolidates all module metadata in one location:

- **`BASE_MODULES`** — A `readonly` array of 19 non-authenticated modules, annotated with `as const satisfies readonly ModuleDescriptor[]`. The `as const` preserves literal id types (e.g., `'bandwidth'` instead of `string`), which is critical for deriving a precise union type.
- **`SQL_MODULE`** — The auth-gated SQL module, kept separate because it has no local generator.
- **`ALL_MODULES`** — A derived array combining base modules with SQL.
- **`ModuleId`** — A union type computed via `(typeof ALL_MODULES)[number]['id']`, which automatically extends when new modules are added.
- **`MODULE_NAMES`**, **`MODULE_DESCRIPTIONS`**, **`MODULE_ICONS`** — Lookup maps typed as `Record<ModuleId, …>`, ensuring every module has matching metadata.
- **`isModuleId(value: string): value is ModuleId`** — A type guard for use at boundaries (URL params, DB rows, RPC payloads).

A new optional `shortName` field supports compact labels in the module grid (e.g., `'OSI'` instead of `'OSI-Modell'`).

### New Generator Registry (`src/app/lib/generators/registry.ts`)

The 18 question generators (SQL excluded) are now registered in a dedicated module with compile-time exhaustiveness checking:

- **`RegistryModuleId = Exclude<ModuleId, 'sql'>`** — The set of modules with local generators.
- **`GENERATORS: Record<RegistryModuleId, () => Question>`** — TypeScript now enforces that every base module has a generator and forbids stray keys. A missing generator is a compile error, not a silent runtime bug.
- **`createQuestionId(module: ModuleId): string`** — Narrowed parameter type prevents id-prefix typos.
- **`GENERATOR_MODULE_IDS`** — Derived from `Object.keys(GENERATORS)`, useful for test coverage.

### Consumer Updates

**`src/app/page.tsx`** — Removed ~190 lines of inline generator wiring and replaced `GENERATORS[module]` with a type-safe lookup guarded by `isModuleId` and an explicit SQL exclusion.

**`src/app/components/ThemeSelector.tsx`** — Removed the local `BASE_MODULES`/`SQL_MODULE` definitions and the hardcoded icon imports, importing from the new shared registry instead. Uses `module.shortName ?? module.name` for compact grid labels.

**`src/app/components/ProgressDashboard.tsx`** — Removed the local `MODULE_NAMES` constant; now imports from the shared registry. The fallback `MODULE_NAMES[id] || p.module` became `isModuleId(id) ? MODULE_NAMES[id] : p.module` — same runtime result, but the type system now verifies that `MODULE_NAMES[id]` is always defined when the guard passes.

### New Test Coverage

**`src/app/lib/__tests__/modules.test.ts`** — Verifies base module count, unique ids, non-empty metadata, SQL auth-gating invariant, and that all three lookup maps agree with the descriptor array.

**`src/app/lib/generators/__tests__/registry.test.ts`** — Iterates over every `GENERATOR_MODULE_IDS` (18 generators, not a 4-item spot-check), verifying each generator produces a valid `Question` with correct id, module, questionText, expectedAnswers, and solutionSteps. Also tests `createQuestionId` prefixing and uniqueness.

**`src/app/components/__tests__/ProgressDashboard.test.tsx`** — Extended the `lucide-react` mock to include all icons transitively pulled in via the new `lib/modules` import.

## Functional Impact

| Aspect | Before | After |
|--------|--------|-------|
| Module id typo (`'subnettting'`) | Compiled silently | Compile error in `MODULE_NAMES`, `GENERATORS`, `createQuestionId` |
| Missing generator for new module | Runtime `undefined` | Compile error on `Record<RegistryModuleId, …>` |
| Drift between module list and lookups | Runtime bug | Compile error |
| Adding a new module | Must remember to update lookups and registry | Automatic via derived union; must add generator to satisfy registry |
| ProgressDashboard label fallback | `MODULE_NAMES[unknownId] \|\| …` | Type-narrowed via `isModuleId` |

No production behavior changes—question ids, generator output, UI labels, and progress lookups are byte-identical to the prior implementation. The four catch-up edits (page.tsx, ProgressDashboard.tsx, two test casts) are the proof that the type tightening works: these patterns are now impossible to write without satisfying the new constraints.
<!-- kody-pr-summary:end -->