### PR TITLE
chore: gitignore .codegraph daemon state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .env*.local
+
+# codegraph index (local code-intelligence daemon state — machine-specific, must not be committed)
+.codegraph/


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## What

Adds the `.codegraph/` directory pattern to `.gitignore` to exclude the codegraph code-intelligence daemon's local index from version control.

## Why

The `.codegraph/` directory contains machine-specific runtime state generated by the codegraph daemon — including a SQLite database (`.db`, `.shm`, `.wal` files), daemon logs, and PID files. This is local, ephemeral state rather than source code that should be shared across contributors.

Previously, this directory was being committed on feature branches (e.g. `fix/security-hardening`, `refactor/module-registry`) but not on `main`. Because the daemon continuously writes to these files, the working tree constantly shows modifications. This causes `git checkout` operations to fail with errors like:

```
error: Your local changes to the following files would be overwritten by checkout
```

Adding the pattern to `.gitignore` ensures future commits won't track these files, while the existing description notes a follow-up step (already present in the PR description) to untrack the directory from feature branches that have already indexed it:

```bash
git rm -r --cached .codegraph/
```

## Change Summary

The modification appends three lines to `.gitignore`:

```diff
+.env*.local
+
+# codegraph index (local code-intelligence daemon state — machine-specific, must not be committed)
+.codegraph/
```

This is a pure repository hygiene change with no runtime or behavioral impact on the application itself — it only affects what Git considers untracked, allowing the codegraph daemon to operate freely without polluting commits or blocking branch operations.
<!-- kody-pr-summary:end -->