### PR TITLE
feat(rate-limit): Upstash-Limiter mit In-Memory-Fallback für die SQL Server Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ GROQ_API_KEY=dein_groq_api_key
 # getrennt zählt — also nicht multi-instance-sicher.
 UPSTASH_REDIS_REST_URL=https://...upstash.io
 UPSTASH_REDIS_REST_TOKEN=dein_upstash_token
+
+# Pepper fürs HMAC des accessHash vor dem Upstash-Identifer. Ohne diesen
+# würde der Hash (und damit das Login-Credential) roh im Upstash-Keyspace
+# und im Analytics-Dashboard landen. 32+ Bytes zufälliges base64 reichen.
+# Rotation invalidiert nur die Rate-Limit-Buckets, NICHT die User-Accounts.
+# Pflicht in Production (sonst startet der Server-Action-Helper nicht).
+RATE_LIMIT_PEPPER=$(openssl rand -base64 32)
 ```
 
 ### Hinweise zur lokalen Nutzung
@@ -110,7 +117,8 @@ UPSTASH_REDIS_REST_TOKEN=dein_upstash_token
 - **Ohne Supabase-Konfiguration** nutzt die App lokale Fallback-Speicherung für Fortschritt/Anmeldung.
 - **Ohne `GROQ_API_KEY`** ist das SQL-Modul nicht funktionsfähig.
 - **Ohne Upstash-Env-Vars** läuft der Rate-Limiter In-Memory (nur für lokales Dev praktikabel; auf Vercel ist er dann nicht multi-instance-sicher und es erscheint eine Warnung im Log).
-- Für Produktionsbetrieb sollten Supabase und Upstash korrekt eingerichtet sein.
+- **Ohne `RATE_LIMIT_PEPPER`** wirft der Rate-Limiter in Production einen Fehler beim ersten Request; im Dev wird `dev:<hash>` als Identifier verwendet (kollidiert nie mit Production-HMACs).
+- Für Produktionsbetrieb sollten Supabase, Upstash und der Pepper korrekt eingerichtet sein.
 
 ## Datenbank-Setup
 

--- a/README.md
+++ b/README.md
@@ -97,13 +97,20 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=dein_supabase_key
 
 # Für das SQL-Modul (KI-Generierung der Aufgaben)
 GROQ_API_KEY=dein_groq_api_key
+
+# Rate-Limit für die SQL Server Action (empfohlen in Produktion).
+# Ohne diese Vars läuft ein In-Memory-Limiter, der pro Vercel-Instance
+# getrennt zählt — also nicht multi-instance-sicher.
+UPSTASH_REDIS_REST_URL=https://...upstash.io
+UPSTASH_REDIS_REST_TOKEN=dein_upstash_token
 ```
 
 ### Hinweise zur lokalen Nutzung
 
 - **Ohne Supabase-Konfiguration** nutzt die App lokale Fallback-Speicherung für Fortschritt/Anmeldung.
 - **Ohne `GROQ_API_KEY`** ist das SQL-Modul nicht funktionsfähig.
-- Für Produktionsbetrieb sollte Supabase korrekt eingerichtet sein.
+- **Ohne Upstash-Env-Vars** läuft der Rate-Limiter In-Memory (nur für lokales Dev praktikabel; auf Vercel ist er dann nicht multi-instance-sicher und es erscheint eine Warnung im Log).
+- Für Produktionsbetrieb sollten Supabase und Upstash korrekt eingerichtet sein.
 
 ## Datenbank-Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@ai-sdk/groq": "^3.0.31",
         "@electric-sql/pglite": "^0.4.2",
         "@supabase/supabase-js": "^2.100.0",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.0",
         "ai": "^6.0.141",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.0.1",
@@ -2994,6 +2996,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vercel/oidc": {
       "version": "3.1.0",
@@ -7993,6 +8028,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.24.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@ai-sdk/groq": "^3.0.31",
     "@electric-sql/pglite": "^0.4.2",
     "@supabase/supabase-js": "^2.100.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "ai": "^6.0.141",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.0.1",

--- a/src/app/actions/generate-sql-exercise.ts
+++ b/src/app/actions/generate-sql-exercise.ts
@@ -122,9 +122,21 @@ export async function generateSqlExercise(accessHash: string): Promise<SqlExerci
   //    failures reject BEFORE this lookup, so probing with garbage hashes
   //    cannot grow the store.
   const rl = await checkRateLimit(accessHash);
-  // Upstash erzeugt für Analytics ein Background-Promise — auf Node-Runtime
-  // per `after()` terminieren, damit der Response nicht blockiert.
-  if (rl.pending) after(rl.pending);
+  // Upstash erzeugt für Analytics ein Background-Promise. Callback-Form
+  // (statt Promise direkt) bewahrt AsyncLocalStorageContext. `.catch`
+  // schluckt Analytics-Fehler, damit sie nicht als unhandled rejection
+  // landen — und wir loggen bewusst nur err.name, nicht err.message
+  // (Upstash packt die REST-URL in die Message, die wie ein Secret zu
+  // behandeln ist).
+  if (rl.pending) {
+    after(() =>
+      rl.pending!.catch((err: unknown) =>
+        console.error('[rateLimit] analytics pending failed:', {
+          name: err instanceof Error ? err.name : 'Error',
+        })
+      )
+    );
+  }
   if (!rl.allowed) {
     const retryAfterSec = Math.ceil((rl.retryAfterMs ?? RATE_LIMIT_WINDOW_MS) / 1000);
     throw new Error(`rate limit: Bitte warte ${retryAfterSec}s.`);

--- a/src/app/actions/generate-sql-exercise.ts
+++ b/src/app/actions/generate-sql-exercise.ts
@@ -2,8 +2,10 @@
 
 import { generateText } from 'ai';
 import { groq } from '@ai-sdk/groq';
+import { after } from 'next/server';
 import { z } from 'zod';
 import { hashExists, isValidAccessHash } from '../lib/auth';
+import { checkRateLimit, RATE_LIMIT_WINDOW_MS } from '../lib/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Type guard for error objects
@@ -21,35 +23,6 @@ function getErrorMessage(error: unknown, fallback: string): string {
   if (isErrorWithMessage(error)) return error.message;
   if (typeof error === 'string') return error;
   return fallback;
-}
-
-// ---------------------------------------------------------------------------
-// Rate limiting — in-memory store (per-instance, reset on cold start)
-// For multi-instance production, replace with Redis/KV
-// ---------------------------------------------------------------------------
-const rateLimitWindowMs = 60 * 1000; // 1 minute
-const rateLimitMaxCalls = 5; // max 5 calls per minute per accessHash
-
-// Buckets are bounded by active real-user count: shape/format and
-// not-in-DB failures reject BEFORE the rate-limit lookup, so an attacker
-// probing with garbage hashes cannot grow this Map.
-const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
-
-function checkRateLimit(accessHash: string): { allowed: boolean; retryAfterMs?: number } {
-  const now = Date.now();
-  const entry = rateLimitStore.get(accessHash);
-
-  if (!entry || now > entry.resetAt) {
-    rateLimitStore.set(accessHash, { count: 1, resetAt: now + rateLimitWindowMs });
-    return { allowed: true };
-  }
-
-  if (entry.count >= rateLimitMaxCalls) {
-    return { allowed: false, retryAfterMs: entry.resetAt - now };
-  }
-
-  entry.count++;
-  return { allowed: true };
 }
 
 // ---------------------------------------------------------------------------
@@ -144,10 +117,16 @@ export async function generateSqlExercise(accessHash: string): Promise<SqlExerci
     throw new Error(message);
   }
 
-  // 3. Check rate limit
-  const { allowed, retryAfterMs } = checkRateLimit(accessHash);
-  if (!allowed) {
-    const retryAfterSec = Math.ceil((retryAfterMs ?? rateLimitWindowMs) / 1000);
+  // 3. Check rate limit (Upstash Redis in prod, In-Memory-Fallback in dev).
+  //    Buckets are bounded by real-user count: shape/format and not-in-DB
+  //    failures reject BEFORE this lookup, so probing with garbage hashes
+  //    cannot grow the store.
+  const rl = await checkRateLimit(accessHash);
+  // Upstash erzeugt für Analytics ein Background-Promise — auf Node-Runtime
+  // per `after()` terminieren, damit der Response nicht blockiert.
+  if (rl.pending) after(rl.pending);
+  if (!rl.allowed) {
+    const retryAfterSec = Math.ceil((rl.retryAfterMs ?? RATE_LIMIT_WINDOW_MS) / 1000);
     throw new Error(`rate limit: Bitte warte ${retryAfterSec}s.`);
   }
 

--- a/src/app/lib/__tests__/rateLimit.test.ts
+++ b/src/app/lib/__tests__/rateLimit.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 // Mock Upstash modules BEFORE the SUT is imported. The SUT's
 // getUpstashLimiter() reads env at first call; if neither
@@ -13,17 +13,12 @@ vi.mock('@upstash/ratelimit', () => {
     return { limit: mockLimit };
   }
   // Static methods used by getUpstashLimiter() (rateLimit.ts:72-78).
-  Object.assign(RatelimitCtor, {
-    fixedWindow: vi.fn(() => 'fixedWindow-config'),
-    slidingWindow: vi.fn(() => 'slidingWindow-config'),
-    tokenBucket: vi.fn(() => 'tokenBucket-config'),
-  });
+  const fixedWindow = vi.fn(() => 'fixedWindow-config');
+  const slidingWindow = vi.fn(() => 'slidingWindow-config');
+  const tokenBucket = vi.fn(() => 'tokenBucket-config');
+  Object.assign(RatelimitCtor, { fixedWindow, slidingWindow, tokenBucket });
   const mock = vi.fn(RatelimitCtor);
-  Object.assign(mock, {
-    fixedWindow: RatelimitCtor.fixedWindow,
-    slidingWindow: RatelimitCtor.slidingWindow,
-    tokenBucket: RatelimitCtor.tokenBucket,
-  });
+  Object.assign(mock, { fixedWindow, slidingWindow, tokenBucket });
   return { Ratelimit: mock };
 });
 

--- a/src/app/lib/__tests__/rateLimit.test.ts
+++ b/src/app/lib/__tests__/rateLimit.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the Upstash modules BEFORE importing the SUT so the module's
+// `getUpstashLimiter()` returns null (no env) and exercises the memory
+// fallback path. This is the path that actually runs in dev / tests.
+vi.mock('@upstash/ratelimit', () => ({
+  Ratelimit: vi.fn(),
+}));
+vi.mock('@upstash/redis', () => ({
+  Redis: vi.fn(),
+}));
+
+import { checkRateLimit, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS } from '../rateLimit';
+
+describe('rateLimit (memory fallback when Upstash env missing)', () => {
+  beforeEach(() => {
+    // Make sure no Upstash env vars are set for the whole suite.
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('allows the first call for an identifier', async () => {
+    const r = await checkRateLimit('user-a');
+    expect(r.allowed).toBe(true);
+    expect(r.mode).toBe('memory');
+    expect(r.limit).toBe(RATE_LIMIT_MAX);
+    expect(r.remaining).toBe(RATE_LIMIT_MAX - 1);
+  });
+
+  it('counts down remaining within the window', async () => {
+    const r1 = await checkRateLimit('user-b');
+    const r2 = await checkRateLimit('user-b');
+    expect(r1.remaining).toBe(RATE_LIMIT_MAX - 1);
+    expect(r2.remaining).toBe(RATE_LIMIT_MAX - 2);
+  });
+
+  it('rejects after RATE_LIMIT_MAX calls and exposes retryAfterMs', async () => {
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      const r = await checkRateLimit('user-c');
+      expect(r.allowed).toBe(true);
+    }
+    const blocked = await checkRateLimit('user-c');
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfterMs).toBeGreaterThan(0);
+    expect(blocked.retryAfterMs).toBeLessThanOrEqual(RATE_LIMIT_WINDOW_MS);
+  });
+
+  it('isolates buckets per identifier', async () => {
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      await checkRateLimit('user-d');
+    }
+    // user-d is now exhausted; user-e must still be allowed.
+    const other = await checkRateLimit('user-e');
+    expect(other.allowed).toBe(true);
+  });
+
+  it('returns a resetMs roughly within the window', async () => {
+    const before = Date.now();
+    const r = await checkRateLimit('user-f');
+    expect(r.resetMs).toBeGreaterThanOrEqual(before);
+    expect(r.resetMs).toBeLessThanOrEqual(before + RATE_LIMIT_WINDOW_MS + 50);
+  });
+
+  it('warns loudly when Upstash env is missing in production', async () => {
+    process.env.NODE_ENV = 'production';
+    const warn = vi.spyOn(console, 'warn');
+    await checkRateLimit('user-g');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/UPSTASH/i);
+  });
+});

--- a/src/app/lib/__tests__/rateLimit.test.ts
+++ b/src/app/lib/__tests__/rateLimit.test.ts
@@ -1,27 +1,65 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 
-// Mock the Upstash modules BEFORE importing the SUT so the module's
-// `getUpstashLimiter()` returns null (no env) and exercises the memory
-// fallback path. This is the path that actually runs in dev / tests.
-vi.mock('@upstash/ratelimit', () => ({
-  Ratelimit: vi.fn(),
-}));
+// Mock Upstash modules BEFORE the SUT is imported. The SUT's
+// getUpstashLimiter() reads env at first call; if neither
+// UPSTASH_REDIS_REST_URL nor UPSTASH_REDIS_REST_TOKEN is set, the mock
+// isn't reached and we exercise the memory fallback. With env set, the
+// mocked Ratelimit constructor returns { limit: mockLimit }.
+const mockLimit = vi.fn();
+
+vi.mock('@upstash/ratelimit', () => {
+  // `function` (not arrow) so the mock is constructable via `new`.
+  function RatelimitCtor() {
+    return { limit: mockLimit };
+  }
+  // Static methods used by getUpstashLimiter() (rateLimit.ts:72-78).
+  Object.assign(RatelimitCtor, {
+    fixedWindow: vi.fn(() => 'fixedWindow-config'),
+    slidingWindow: vi.fn(() => 'slidingWindow-config'),
+    tokenBucket: vi.fn(() => 'tokenBucket-config'),
+  });
+  const mock = vi.fn(RatelimitCtor);
+  Object.assign(mock, {
+    fixedWindow: RatelimitCtor.fixedWindow,
+    slidingWindow: RatelimitCtor.slidingWindow,
+    tokenBucket: RatelimitCtor.tokenBucket,
+  });
+  return { Ratelimit: mock };
+});
+
 vi.mock('@upstash/redis', () => ({
-  Redis: vi.fn(),
+  Redis: { fromEnv: vi.fn(() => ({})) },
 }));
 
-import { checkRateLimit, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS } from '../rateLimit';
+// Clean env state + module cache before every test. rateLimit.ts reads
+// process.env on first call and caches the limiter, so without this the
+// first test's state would leak into subsequent tests.
+beforeEach(() => {
+  vi.stubEnv('UPSTASH_REDIS_REST_URL', '');
+  vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', '');
+  vi.stubEnv('RATE_LIMIT_PEPPER', '');
+  vi.stubEnv('NODE_ENV', 'test');
+  mockLimit.mockReset();
+  vi.resetModules();
+});
 
-describe('rateLimit (memory fallback when Upstash env missing)', () => {
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// Memory fallback (Upstash env absent)
+// ---------------------------------------------------------------------------
+describe('rateLimit — memory fallback', () => {
   beforeEach(() => {
-    // Make sure no Upstash env vars are set for the whole suite.
-    delete process.env.UPSTASH_REDIS_REST_URL;
-    delete process.env.UPSTASH_REDIS_REST_TOKEN;
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   it('allows the first call for an identifier', async () => {
+    const { checkRateLimit, __resetRateLimitForTests, RATE_LIMIT_MAX } = await import('../rateLimit');
+    __resetRateLimitForTests();
     const r = await checkRateLimit('user-a');
     expect(r.allowed).toBe(true);
     expect(r.mode).toBe('memory');
@@ -30,6 +68,8 @@ describe('rateLimit (memory fallback when Upstash env missing)', () => {
   });
 
   it('counts down remaining within the window', async () => {
+    const { checkRateLimit, __resetRateLimitForTests, RATE_LIMIT_MAX } = await import('../rateLimit');
+    __resetRateLimitForTests();
     const r1 = await checkRateLimit('user-b');
     const r2 = await checkRateLimit('user-b');
     expect(r1.remaining).toBe(RATE_LIMIT_MAX - 1);
@@ -37,6 +77,9 @@ describe('rateLimit (memory fallback when Upstash env missing)', () => {
   });
 
   it('rejects after RATE_LIMIT_MAX calls and exposes retryAfterMs', async () => {
+    const { checkRateLimit, __resetRateLimitForTests, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS } =
+      await import('../rateLimit');
+    __resetRateLimitForTests();
     for (let i = 0; i < RATE_LIMIT_MAX; i++) {
       const r = await checkRateLimit('user-c');
       expect(r.allowed).toBe(true);
@@ -49,26 +92,163 @@ describe('rateLimit (memory fallback when Upstash env missing)', () => {
   });
 
   it('isolates buckets per identifier', async () => {
+    const { checkRateLimit, __resetRateLimitForTests, RATE_LIMIT_MAX } = await import('../rateLimit');
+    __resetRateLimitForTests();
     for (let i = 0; i < RATE_LIMIT_MAX; i++) {
       await checkRateLimit('user-d');
     }
-    // user-d is now exhausted; user-e must still be allowed.
     const other = await checkRateLimit('user-e');
     expect(other.allowed).toBe(true);
   });
 
   it('returns a resetMs roughly within the window', async () => {
+    const { checkRateLimit, __resetRateLimitForTests, RATE_LIMIT_WINDOW_MS } =
+      await import('../rateLimit');
+    __resetRateLimitForTests();
     const before = Date.now();
     const r = await checkRateLimit('user-f');
     expect(r.resetMs).toBeGreaterThanOrEqual(before);
     expect(r.resetMs).toBeLessThanOrEqual(before + RATE_LIMIT_WINDOW_MS + 50);
   });
 
-  it('warns loudly when Upstash env is missing in production', async () => {
-    process.env.NODE_ENV = 'production';
-    const warn = vi.spyOn(console, 'warn');
+  it('warns in production when Upstash env is missing', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('RATE_LIMIT_PEPPER', 'test-pepper');
+    const warnSpy = vi.spyOn(console, 'warn');
+    const { checkRateLimit, __resetRateLimitForTests } = await import('../rateLimit');
+    __resetRateLimitForTests();
     await checkRateLimit('user-g');
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toMatch(/UPSTASH/i);
+    const upstashWarns = warnSpy.mock.calls.filter((call) =>
+      String(call[0] ?? '').includes('UPSTASH')
+    );
+    expect(upstashWarns.length).toBe(1);
+  });
+
+  it('does not warn in production when Upstash env is missing more than once per process', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('RATE_LIMIT_PEPPER', 'test-pepper');
+    const warnSpy = vi.spyOn(console, 'warn');
+    const { checkRateLimit, __resetRateLimitForTests } = await import('../rateLimit');
+    __resetRateLimitForTests();
+    await checkRateLimit('user-h1');
+    await checkRateLimit('user-h2');
+    await checkRateLimit('user-h3');
+    const upstashWarns = warnSpy.mock.calls.filter((call) =>
+      String(call[0] ?? '').includes('UPSTASH')
+    );
+    expect(upstashWarns.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hashIdentifier — accessHash credential defense
+// ---------------------------------------------------------------------------
+describe('hashIdentifier', () => {
+  it('produces a stable hex digest for a fixed pepper', async () => {
+    vi.stubEnv('RATE_LIMIT_PEPPER', 'test-pepper-fixed');
+    vi.stubEnv('NODE_ENV', 'test');
+    const { hashIdentifier } = await import('../rateLimit');
+    expect(hashIdentifier('user-a')).toMatch(/^[a-f0-9]{64}$/);
+    expect(hashIdentifier('user-a')).toBe(hashIdentifier('user-a'));
+    expect(hashIdentifier('user-a')).not.toBe(hashIdentifier('user-b'));
+  });
+
+  it('different peppers produce different digests', async () => {
+    vi.stubEnv('RATE_LIMIT_PEPPER', 'pepper-A');
+    vi.stubEnv('NODE_ENV', 'test');
+    const { hashIdentifier: h1 } = await import('../rateLimit');
+    const a = h1('user-x');
+    vi.stubEnv('RATE_LIMIT_PEPPER', 'pepper-B');
+    vi.resetModules();
+    const { hashIdentifier: h2 } = await import('../rateLimit');
+    const b = h2('user-x');
+    expect(a).not.toBe(b);
+  });
+
+  it('throws in production when pepper is missing', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const { hashIdentifier } = await import('../rateLimit');
+    expect(() => hashIdentifier('user')).toThrow(/RATE_LIMIT_PEPPER/);
+  });
+
+  it('uses dev: prefix when no pepper is set outside production', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const { hashIdentifier } = await import('../rateLimit');
+    expect(hashIdentifier('user-a')).toBe('dev:user-a');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Upstash failure handling — fail-open → fail-closed, URL redaction
+// ---------------------------------------------------------------------------
+describe('rateLimit — Upstash failure handling', () => {
+  beforeEach(() => {
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', 'https://test.upstash.io');
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', 'test-token');
+    vi.stubEnv('RATE_LIMIT_PEPPER', 'test-pepper');
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('fail-opens on a single Upstash error and tags mode=upstash-degraded', async () => {
+    mockLimit.mockRejectedValueOnce(new Error('HTTP 503 from https://test.upstash.io'));
+    const { checkRateLimit, __resetRateLimitForTests } = await import('../rateLimit');
+    __resetRateLimitForTests();
+    const r = await checkRateLimit('user-x');
+    expect(r.allowed).toBe(true);
+    expect(r.mode).toBe('upstash-degraded');
+  });
+
+  it('fail-closes after FAILURE_THRESHOLD consecutive failures', async () => {
+    mockLimit.mockRejectedValue(new Error('boom'));
+    const { checkRateLimit, __resetRateLimitForTests } = await import('../rateLimit');
+    __resetRateLimitForTests();
+    for (let i = 0; i < 5; i++) {
+      await checkRateLimit(`user-${i}`);
+    }
+    const r = await checkRateLimit('user-z');
+    expect(r.allowed).toBe(false);
+    expect(r.mode).toBe('upstash-degraded');
+    expect(r.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('does NOT log err.message (URL redaction)', async () => {
+    const SECRET_URL = 'https://secret-xyz.upstash.io';
+    mockLimit.mockRejectedValueOnce(new Error(`HTTP 500 from ${SECRET_URL}`));
+    const errSpy = vi.spyOn(console, 'error');
+    const { checkRateLimit, __resetRateLimitForTests } = await import('../rateLimit');
+    __resetRateLimitForTests();
+    await checkRateLimit('user-z');
+    const logged = errSpy.mock.calls
+      .flat()
+      .map((c) => {
+        try {
+          return JSON.stringify(c);
+        } catch {
+          return String(c);
+        }
+      })
+      .join(' ');
+    expect(logged).not.toContain(SECRET_URL);
+    expect(logged).not.toContain('HTTP 500');
+  });
+
+  it('resets failure streak on a successful call', async () => {
+    mockLimit
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({
+        success: true,
+        limit: 5,
+        remaining: 4,
+        reset: Date.now() + 60_000,
+      })
+      .mockRejectedValueOnce(new Error('boom'));
+    const { checkRateLimit, __resetRateLimitForTests } = await import('../rateLimit');
+    __resetRateLimitForTests();
+    await checkRateLimit('user-w');
+    await checkRateLimit('user-w');
+    const r = await checkRateLimit('user-w');
+    expect(r.allowed).toBe(true);
+    expect(r.mode).toBe('upstash-degraded');
   });
 });

--- a/src/app/lib/rateLimit.ts
+++ b/src/app/lib/rateLimit.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 
@@ -6,7 +7,16 @@ import { Redis } from '@upstash/redis';
 // (5 Calls pro Minute pro accessHash), aber jetzt produktionstauglich.
 // ---------------------------------------------------------------------------
 export const RATE_LIMIT_MAX = 5;
-export const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const RATE_LIMIT_WINDOW_SECONDS = 60;
+export const RATE_LIMIT_WINDOW_MS = RATE_LIMIT_WINDOW_SECONDS * 1000;
+
+// Fail-closed: nach N Upstash-Fehlern innerhalb des Fensters wird auf
+// fail-closed geschaltet, damit ein DoS / Ausfall den Limiter nicht
+// dauerhaft aushebelt (sonst hätten wir die alte Bypass-Lücke nur verlagert).
+const FAILURE_THRESHOLD = 5;
+const FAILURE_WINDOW_MS = 30_000;
+
+export type RateLimitMode = 'upstash' | 'memory' | 'upstash-degraded';
 
 export type RateLimitResult = {
   allowed: boolean;
@@ -17,10 +27,34 @@ export type RateLimitResult = {
   /** Convenience für Caller; nur gesetzt wenn !allowed. */
   retryAfterMs?: number;
   reason?: 'timeout' | 'cacheBlock' | 'denyList';
-  /** Upstash-Analytics-Backgroundwork; Caller sollte das per after() / waitUntil() terminieren. */
+  /** Upstash-Analytics-Backgroundwork. Caller sollte das per after() terminieren. */
   pending?: Promise<unknown>;
-  mode: 'upstash' | 'memory';
+  mode: RateLimitMode;
 };
+
+// ---------------------------------------------------------------------------
+// Identifier-Hashing: der accessHash IST die einzige Credential. Roh an
+// Upstash geben → landet im Redis-Keyspace UND im Analytics-Dashboard.
+// Jeder mit Dashboard-Read-Access könnte so User-Logins übernehmen.
+// Daher HMAC mit einer prozessspezifischen Pepper-Variable.
+//
+// Dev: ohne Pepper fallback `dev:<id>` (kollidiert nie mit prod-digests).
+// Prod: ohne Pepper ist ein Hard-Fail.
+// ---------------------------------------------------------------------------
+const RATE_LIMIT_PEPPER = process.env.RATE_LIMIT_PEPPER;
+
+export function hashIdentifier(id: string): string {
+  if (!RATE_LIMIT_PEPPER) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        'RATE_LIMIT_PEPPER muss in Production gesetzt sein (sonst landet ' +
+          'der accessHash roh im Upstash-Dashboard).'
+      );
+    }
+    return `dev:${id}`;
+  }
+  return createHmac('sha256', RATE_LIMIT_PEPPER).update(id).digest('hex');
+}
 
 // ---------------------------------------------------------------------------
 // Upstash-Limiter (lazy init). Wird nur erzeugt, wenn beide Env-Vars da sind.
@@ -35,7 +69,7 @@ function getUpstashLimiter(): Ratelimit | null {
 
   _upstash = new Ratelimit({
     redis: Redis.fromEnv(),
-    limiter: Ratelimit.fixedWindow(RATE_LIMIT_MAX, '60 s'),
+    limiter: Ratelimit.fixedWindow(RATE_LIMIT_MAX, `${RATE_LIMIT_WINDOW_SECONDS} s`),
     analytics: true,
     prefix: 'rl:ihk',
     // Default 5s ist für eine Server-Action viel zu lang — lieber fail-fast.
@@ -48,8 +82,7 @@ function getUpstashLimiter(): Ratelimit | null {
 // ---------------------------------------------------------------------------
 // In-Memory-Fallback (Dev ohne Env / bewusst gewählte Notbremse).
 // ACHTUNG: Pro Vercel-Instance getrennt — auf Edge / Serverless NICHT
-// multi-instance-sicher. Genau das, was der vorige Kommentar am alten
-// Map schon angemerkt hat; jetzt wenigstens laut signalisiert.
+// multi-instance-sicher.
 // ---------------------------------------------------------------------------
 type MemEntry = { count: number; resetAt: number };
 const mem = new Map<string, MemEntry>();
@@ -58,12 +91,13 @@ function checkMemory(id: string): RateLimitResult {
   const now = Date.now();
   const entry = mem.get(id);
   if (!entry || now > entry.resetAt) {
-    mem.set(id, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    const resetAt = now + RATE_LIMIT_WINDOW_MS;
+    mem.set(id, { count: 1, resetAt });
     return {
       allowed: true,
       limit: RATE_LIMIT_MAX,
       remaining: RATE_LIMIT_MAX - 1,
-      resetMs: mem.get(id)!.resetAt,
+      resetMs: resetAt,
       mode: 'memory',
     };
   }
@@ -87,28 +121,61 @@ function checkMemory(id: string): RateLimitResult {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Failure-Streak-Tracking (per Node-Prozess). Auf Vercel-Warm-Instance lebt
+// das Counter mehrere Stunden; Cold-Start resettet es bewusst — ein einzelner
+// frischer Prozess darf fail-open laufen, ein dauerhafter Upstash-Ausfall
+// soll aber fail-closed werden.
+// ---------------------------------------------------------------------------
+let failures = 0;
+let firstFailureAt = 0;
+let warnedMissingUpstash = false;
+
+function recordUpstashFailure(): boolean /* failClosed */ {
+  const now = Date.now();
+  if (now - firstFailureAt > FAILURE_WINDOW_MS) {
+    firstFailureAt = now;
+    failures = 1;
+    return false;
+  }
+  failures++;
+  return failures >= FAILURE_THRESHOLD;
+}
+
+/** Test-only hook: setzt State zurück. */
+export function __resetRateLimitForTests(): void {
+  warnedMissingUpstash = false;
+  failures = 0;
+  firstFailureAt = 0;
+  mem.clear();
+}
+
 /**
- * Prüft, ob `identifier` (bei uns der accessHash) im aktuellen Fenster
- * noch einen Call frei hat. Upstash, wenn env gesetzt, sonst In-Memory.
+ * Prüft, ob `identifier` (bei uns der accessHash) im aktuellen Fenster noch
+ * einen Call frei hat. Upstash, wenn env gesetzt, sonst In-Memory.
  *
- * Fail-open: Bei Upstash-Fehlern (Timeout, Netz) wird der Request
- * durchgelassen — Rate-Limit soll nicht selbst zur Downtime führen.
- * Der Fehler wird geloggt.
+ * Fail-closed nach FAILURE_THRESHOLD Upstash-Fehlern in FAILURE_WINDOW_MS.
  */
 export async function checkRateLimit(identifier: string): Promise<RateLimitResult> {
   const limiter = getUpstashLimiter();
   if (!limiter) {
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV === 'production' && !warnedMissingUpstash) {
       console.warn(
         '[rateLimit] UPSTASH_REDIS_REST_URL/TOKEN fehlen — fallback In-Memory. ' +
           'Auf Vercel ist der Limiter dann NICHT multi-instance-sicher.'
       );
+      warnedMissingUpstash = true;
     }
-    return checkMemory(identifier);
+    return checkMemory(hashIdentifier(identifier));
   }
 
+  const hashedId = hashIdentifier(identifier);
+
   try {
-    const r = await limiter.limit(identifier);
+    const r = await limiter.limit(hashedId);
+    // Erfolg — Failure-Streak resetten.
+    failures = 0;
+    firstFailureAt = 0;
     return {
       allowed: r.success,
       limit: r.limit,
@@ -120,13 +187,33 @@ export async function checkRateLimit(identifier: string): Promise<RateLimitResul
       mode: 'upstash',
     };
   } catch (err) {
-    console.error('[rateLimit] Upstash-Call fehlgeschlagen, fail-open:', err);
+    const failClosed = recordUpstashFailure();
+    // URL-Redaktion: @upstash/redis inkludiert die REST-URL in err.message
+    // (URL + Token sind die Credentials). Wir loggen deshalb nur Name +
+    // ggf. Status, niemals die Message.
+    const e = err as { name?: string; status?: number };
+    console.error('[rateLimit] Upstash-Call fehlgeschlagen:', {
+      name: e?.name ?? 'Error',
+      status: typeof e?.status === 'number' ? e.status : undefined,
+      failures,
+      failClosed,
+    });
+    if (failClosed) {
+      return {
+        allowed: false,
+        limit: RATE_LIMIT_MAX,
+        remaining: 0,
+        resetMs: Date.now() + RATE_LIMIT_WINDOW_MS,
+        retryAfterMs: RATE_LIMIT_WINDOW_MS,
+        mode: 'upstash-degraded',
+      };
+    }
     return {
       allowed: true,
       limit: RATE_LIMIT_MAX,
       remaining: RATE_LIMIT_MAX,
       resetMs: Date.now() + RATE_LIMIT_WINDOW_MS,
-      mode: 'upstash',
+      mode: 'upstash-degraded',
     };
   }
 }

--- a/src/app/lib/rateLimit.ts
+++ b/src/app/lib/rateLimit.ts
@@ -1,0 +1,132 @@
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+
+// ---------------------------------------------------------------------------
+// Rate limit config — gleiche Semantik wie der bisherige In-Memory-Limiter
+// (5 Calls pro Minute pro accessHash), aber jetzt produktionstauglich.
+// ---------------------------------------------------------------------------
+export const RATE_LIMIT_MAX = 5;
+export const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+
+export type RateLimitResult = {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  /** Absolute ms-Timestamp, an dem das Window zurücksetzt. */
+  resetMs: number;
+  /** Convenience für Caller; nur gesetzt wenn !allowed. */
+  retryAfterMs?: number;
+  reason?: 'timeout' | 'cacheBlock' | 'denyList';
+  /** Upstash-Analytics-Backgroundwork; Caller sollte das per after() / waitUntil() terminieren. */
+  pending?: Promise<unknown>;
+  mode: 'upstash' | 'memory';
+};
+
+// ---------------------------------------------------------------------------
+// Upstash-Limiter (lazy init). Wird nur erzeugt, wenn beide Env-Vars da sind.
+// ---------------------------------------------------------------------------
+let _upstash: Ratelimit | null = null;
+
+function getUpstashLimiter(): Ratelimit | null {
+  if (_upstash) return _upstash;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  _upstash = new Ratelimit({
+    redis: Redis.fromEnv(),
+    limiter: Ratelimit.fixedWindow(RATE_LIMIT_MAX, '60 s'),
+    analytics: true,
+    prefix: 'rl:ihk',
+    // Default 5s ist für eine Server-Action viel zu lang — lieber fail-fast.
+    timeout: 1000,
+    ephemeralCache: new Map(),
+  });
+  return _upstash;
+}
+
+// ---------------------------------------------------------------------------
+// In-Memory-Fallback (Dev ohne Env / bewusst gewählte Notbremse).
+// ACHTUNG: Pro Vercel-Instance getrennt — auf Edge / Serverless NICHT
+// multi-instance-sicher. Genau das, was der vorige Kommentar am alten
+// Map schon angemerkt hat; jetzt wenigstens laut signalisiert.
+// ---------------------------------------------------------------------------
+type MemEntry = { count: number; resetAt: number };
+const mem = new Map<string, MemEntry>();
+
+function checkMemory(id: string): RateLimitResult {
+  const now = Date.now();
+  const entry = mem.get(id);
+  if (!entry || now > entry.resetAt) {
+    mem.set(id, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return {
+      allowed: true,
+      limit: RATE_LIMIT_MAX,
+      remaining: RATE_LIMIT_MAX - 1,
+      resetMs: mem.get(id)!.resetAt,
+      mode: 'memory',
+    };
+  }
+  if (entry.count >= RATE_LIMIT_MAX) {
+    return {
+      allowed: false,
+      limit: RATE_LIMIT_MAX,
+      remaining: 0,
+      resetMs: entry.resetAt,
+      retryAfterMs: entry.resetAt - now,
+      mode: 'memory',
+    };
+  }
+  entry.count++;
+  return {
+    allowed: true,
+    limit: RATE_LIMIT_MAX,
+    remaining: RATE_LIMIT_MAX - entry.count,
+    resetMs: entry.resetAt,
+    mode: 'memory',
+  };
+}
+
+/**
+ * Prüft, ob `identifier` (bei uns der accessHash) im aktuellen Fenster
+ * noch einen Call frei hat. Upstash, wenn env gesetzt, sonst In-Memory.
+ *
+ * Fail-open: Bei Upstash-Fehlern (Timeout, Netz) wird der Request
+ * durchgelassen — Rate-Limit soll nicht selbst zur Downtime führen.
+ * Der Fehler wird geloggt.
+ */
+export async function checkRateLimit(identifier: string): Promise<RateLimitResult> {
+  const limiter = getUpstashLimiter();
+  if (!limiter) {
+    if (process.env.NODE_ENV === 'production') {
+      console.warn(
+        '[rateLimit] UPSTASH_REDIS_REST_URL/TOKEN fehlen — fallback In-Memory. ' +
+          'Auf Vercel ist der Limiter dann NICHT multi-instance-sicher.'
+      );
+    }
+    return checkMemory(identifier);
+  }
+
+  try {
+    const r = await limiter.limit(identifier);
+    return {
+      allowed: r.success,
+      limit: r.limit,
+      remaining: r.remaining,
+      resetMs: r.reset,
+      retryAfterMs: r.success ? undefined : Math.max(0, r.reset - Date.now()),
+      reason: r.reason,
+      pending: r.pending,
+      mode: 'upstash',
+    };
+  } catch (err) {
+    console.error('[rateLimit] Upstash-Call fehlgeschlagen, fail-open:', err);
+    return {
+      allowed: true,
+      limit: RATE_LIMIT_MAX,
+      remaining: RATE_LIMIT_MAX,
+      resetMs: Date.now() + RATE_LIMIT_WINDOW_MS,
+      mode: 'upstash',
+    };
+  }
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## What & Why

This PR replaces the **per-instance in-memory rate limiter** on the SQL exercise generation server action with a **production-grade Upstash Redis limiter** plus a clearly-labeled in-memory fallback for local development.

The previous limiter used a `Map<string, …>` counted to 5 calls/minute per `accessHash` per lambda instance. Because Vercel runs many isolated lambda instances, an attacker could simply target a fresh cold-start instance to bypass it — a flaw the original code’s own comment flagged as TODO. Review point #8 from the security hardening review (`IMPROVEMENT_PLAN.md` P0 #3) is now closed.

## Functional Changes

**New module `src/app/lib/rateLimit.ts`**
- Single exported API: `checkRateLimit(identifier): Promise<RateLimitResult>`.
- Uses `@upstash/ratelimit` (fixed window, 5 / 60 s) on top of `@upstash/redis` when `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are set.
- Uses HTTP transport (cold-start friendly), 1-second Upstash timeout, and an in-memory `ephemeralCache` to deduplicate bursts within the same instance.
- Falls back to an **in-memory** limiter with identical 5/min contract when the env vars are missing; emits a loud `console.warn` in production so the misconfiguration is not silent.
- **Fail-open** on transient Upstash errors (timeout / network): logs and returns `allowed: true` so the limiter itself can never cause downtime.
- Returns a structured `RateLimitResult` including `limit`, `remaining`, absolute `resetMs`, optional `retryAfterMs`, optional Upstash `reason` (`timeout | cacheBlock | denyList`), and an optional `pending` Promise from Upstash analytics.

**Refactor of `src/app/actions/generate-sql-exercise.ts`**
- Removed the inline `Map`-based limiter (≈30 lines) and the `rateLimitWindowMs` constant.
- Imports `checkRateLimit` and `RATE_LIMIT_WINDOW_MS` from the new module.
- Awaits the limiter (now async because Upstash is HTTP-based) and hands the Upstash analytics `pending` Promise to Next’s `after()` so background telemetry never blocks the response.
- Preserves the existing user-facing error message (`rate limit: Bitte warte Ns.`) and the existing comment about bucket size being bounded by real users (shape/format and not-in-DB checks run earlier).
- Behavioral contract — **5 calls/minute per accessHash, fixed window, same error UX** — is preserved 1:1, as called out in the PR description.

**New tests `src/app/lib/__tests__/rateLimit.test.ts`**
- Mocks `@upstash/ratelimit` and `@upstash/redis` so the helper always exercises the memory fallback (the path actually running in dev/CI).
- Covers: first call allowed with `remaining = RATE_LIMIT_MAX - 1`; remaining counts down per call; rejection after `RATE_LIMIT_MAX` with valid `retryAfterMs`; bucket isolation per identifier; sane `resetMs`; and a production-mode warning when Upstash env is absent.

**Dependencies**
- Added `@upstash/ratelimit` and `@upstash/redis` to `package.json` / `package-lock.json`.

**Docs (`README.md`)**
- Documented `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in the env section.
- Added a note that without Upstash the limiter runs in-memory, is not multi-instance-safe on Vercel, and emits a warning — explicitly nudging operators to configure Upstash for production.

## Verification
- `npx tsc --noEmit`, `npm test` (203 tests / 18 files), `npm run build`, `npm run lint` all pass per the PR description.
<!-- kody-pr-summary:end -->