### PR TITLE
feat(ux): Error-Boundary, 404-Seite, A11y, Shortcuts, Changelog-Pill

### DIFF
--- a/src/app/components/AuthModal.tsx
+++ b/src/app/components/AuthModal.tsx
@@ -168,25 +168,28 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
     }
   };
 
-  /** Pasted input — auto-extract the hash from surrounding noise and
-   *  surface a brief confirmation so the user knows it landed. */
+  /** Pasted input — intercept the raw clipboard text, extract a valid hash
+   *  from surrounding noise, and write the cleaned value into this controlled
+   *  input. That keeps the counter/validation tied to normalized codes only. */
   const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
     const pasted = e.clipboardData.getData('text');
     const normalized = normalizePastedHash(pasted);
-    // Use rAF + setTimeout so we apply AFTER React's default paste behavior
-    // (which would otherwise put the full clipboard text into the input
-    // and break our length-counter). We let the paste propagate, then
-    // overwrite the input value with the cleaned hash on the next tick.
     e.preventDefault();
     if (!normalized) {
       setError('Eingefügter Text enthält keinen gültigen Code.');
+      setPasteHint(false);
       return;
     }
     setInputHash(normalized);
     setError('');
     setPasteHint(true);
-    setTimeout(() => setPasteHint(false), 3000);
   };
+
+  useEffect(() => {
+    if (!pasteHint) return;
+    const timer = window.setTimeout(() => setPasteHint(false), 3000);
+    return () => window.clearTimeout(timer);
+  }, [pasteHint]);
 
   if (!isOpen) return null;
 
@@ -401,8 +404,8 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
                       </>
                     ) : (
                       <>
-                        Noch {HASH_LENGTH - loginValidation.length} Zeichen
-                        {loginValidation.length === 1 ? '' : ''} fehlen.
+                        Noch {HASH_LENGTH - loginValidation.length} Zeichen{' '}
+                        {HASH_LENGTH - loginValidation.length === 1 ? 'fehlt.' : 'fehlen.'}
                       </>
                     )}
                   </p>

--- a/src/app/components/AuthModal.tsx
+++ b/src/app/components/AuthModal.tsx
@@ -1,14 +1,64 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type ClipboardEvent } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Copy, Check, AlertTriangle, LogIn, Key } from 'lucide-react';
+import {
+  X,
+  Copy,
+  Check,
+  AlertTriangle,
+  LogIn,
+  Key,
+  ClipboardPaste,
+  CircleAlert,
+  CircleCheck,
+} from 'lucide-react';
 
 interface AuthModalProps {
   isOpen: boolean;
   onClose: () => void;
   onLogin: (hash: string) => Promise<{ success: boolean; error?: string }>;
   onRegister: () => Promise<string | null>;
+}
+
+/** Access hash format: 12 alphanumeric chars, case-sensitive. */
+const HASH_LENGTH = 12;
+const HASH_FORMAT = /^[A-Za-z0-9]+$/;
+
+/** Extract only the characters that match the access-hash format from
+ *  arbitrary clipboard content (handles pasted whitespace, newlines,
+ *  surrounding "Here is my code: …" prose, leading BOM, etc.).
+ *
+ *  Strategy: match a 12-char alphanumeric run that's bounded by
+ *  non-alphanumerics (or start/end of string). This handles both
+ *  "ab12cd34ef56" by itself and
+ *  "Hier dein Code: ab12cd34ef56 — viel Erfolg" gracefully: the colon
+ *  and em-dash delimit the code, so we don't accidentally pick up
+ *  neighboring words like "HierdeinCode".
+ *  If no such bounded run exists, fall back to the first HASH_LENGTH
+ *  alphanumeric chars (best-effort). */
+function normalizePastedHash(raw: string): string {
+  const boundedRe = new RegExp(
+    `(?:^|[^A-Za-z0-9])([A-Za-z0-9]{${HASH_LENGTH}})(?:[^A-Za-z0-9]|$)`,
+  );
+  const bounded = raw.match(boundedRe);
+  if (bounded) return bounded[1];
+  const cleaned = raw.replace(/[^A-Za-z0-9]/g, '');
+  return cleaned.slice(0, HASH_LENGTH);
+}
+
+function validateHashShape(raw: string): {
+  trimmed: string;
+  length: number;
+  lengthOk: boolean;
+  formatOk: boolean;
+  isValid: boolean;
+} {
+  const trimmed = raw.trim();
+  const length = trimmed.length;
+  const formatOk = length === 0 || HASH_FORMAT.test(trimmed);
+  const lengthOk = length === HASH_LENGTH;
+  return { trimmed, length, lengthOk, formatOk, isValid: lengthOk && formatOk };
 }
 
 export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: AuthModalProps) {
@@ -18,6 +68,8 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  /** True for ~3s after a paste, so the "Eingefügt" hint is visible. */
+  const [pasteHint, setPasteHint] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -26,6 +78,7 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
       setInputHash('');
       setError('');
       setCopied(false);
+      setPasteHint(false);
     }
   }, [isOpen]);
 
@@ -48,22 +101,29 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
   };
 
   const handleLogin = async () => {
-    const trimmedHash = inputHash.trim();
-
-    if (!trimmedHash || trimmedHash.length !== 12) {
+    const { trimmed, isValid } = validateHashShape(inputHash);
+    if (!trimmed) {
       setError('Bitte gib einen gültigen 12-stelligen Code ein.');
+      return;
+    }
+    if (!isValid) {
+      // Most common cause: pasted text contained more than just the code,
+      // or a wrong character snuck in. Guide the user to the inline
+      // feedback below the input.
+      setError(
+        trimmed.length !== HASH_LENGTH
+          ? `Der Code muss genau ${HASH_LENGTH} Zeichen haben (aktuell: ${trimmed.length}).`
+          : 'Der Code enthält ungültige Zeichen. Erlaubt: A–Z, a–z, 0–9.',
+      );
       return;
     }
     setError('');
     setLoading(true);
     try {
-      const result = await onLogin(inputHash.trim());
+      const result = await onLogin(trimmed);
       if (result.success) {
-        // Login succeeded in page.tsx (user set, modal closed there).
-        // Just reset local loading state; the modal will close via page.tsx state.
         setInputHash(''); // Clear the input for next time
       } else {
-        // Login failed – show error message
         setError(result.error || 'Anmeldung fehlgeschlagen.');
       }
     } catch {
@@ -79,7 +139,6 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
     try {
       const result = await onLogin(hash);
       if (result.success) {
-        // Login succeeded in page.tsx. Modal will close via page.tsx state.
         setHash(''); // Clear registered hash after successful login
       } else {
         setError(result.error || 'Anmeldung fehlgeschlagen.');
@@ -109,7 +168,37 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
     }
   };
 
+  /** Pasted input — auto-extract the hash from surrounding noise and
+   *  surface a brief confirmation so the user knows it landed. */
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    const pasted = e.clipboardData.getData('text');
+    const normalized = normalizePastedHash(pasted);
+    // Use rAF + setTimeout so we apply AFTER React's default paste behavior
+    // (which would otherwise put the full clipboard text into the input
+    // and break our length-counter). We let the paste propagate, then
+    // overwrite the input value with the cleaned hash on the next tick.
+    e.preventDefault();
+    if (!normalized) {
+      setError('Eingefügter Text enthält keinen gültigen Code.');
+      return;
+    }
+    setInputHash(normalized);
+    setError('');
+    setPasteHint(true);
+    setTimeout(() => setPasteHint(false), 3000);
+  };
+
   if (!isOpen) return null;
+
+  // For the login view: derived validation state for inline feedback.
+  const loginValidation = validateHashShape(inputHash);
+  const loginHintClass = !loginValidation.length
+    ? 'text-slate-500'
+    : loginValidation.isValid
+      ? 'text-emerald-400'
+      : loginValidation.formatOk
+        ? 'text-amber-400'
+        : 'text-rose-400';
 
   return (
     <AnimatePresence>
@@ -140,6 +229,7 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
             <button
               onClick={onClose}
               className="p-2 text-slate-500 hover:text-slate-300 hover:bg-slate-800 rounded-lg transition-colors"
+              aria-label="Schließen"
             >
               <X className="w-5 h-5" />
             </button>
@@ -213,6 +303,7 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
                     <button
                       onClick={copyToClipboard}
                       className="px-4 py-3 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-lg transition-colors"
+                      aria-label="Code in die Zwischenablage kopieren"
                     >
                       {copied ? (
                         <Check className="w-5 h-5 text-emerald-400" />
@@ -221,6 +312,9 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
                       )}
                     </button>
                   </div>
+                  <p className="mt-2 text-xs text-slate-500">
+                    Tipp: Mit dem Button oben kopieren und sicher notieren.
+                  </p>
                 </div>
 
                 <button
@@ -236,25 +330,100 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
             {mode === 'login' && (
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-slate-400 mb-2">
-                    Zugangscode
+                  <label
+                    htmlFor="access-hash-input"
+                    className="flex items-center justify-between text-sm font-medium text-slate-400 mb-2"
+                  >
+                    <span>Zugangscode</span>
+                    <span className={`text-xs font-mono ${loginHintClass}`}>
+                      {loginValidation.length}/{HASH_LENGTH}
+                    </span>
                   </label>
-                  <input
-                    type="text"
-                    value={inputHash}
-                    onChange={(e) => setInputHash(e.target.value)}
-                    maxLength={12}
-                    disabled={loading}
-                    placeholder="Ab12cD34eF56"
-                    autoCapitalize="off"
-                    autoCorrect="off"
-                    spellCheck={false}
-                    className="w-full px-4 py-3 bg-slate-950 border border-slate-800 rounded-lg text-slate-100 font-mono text-lg tracking-wider placeholder-slate-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:border-emerald-500/50 transition-all disabled:opacity-50"
-                  />
-                  <p className="mt-2 text-xs text-slate-500">
-                    12-stelliger alphanumerischer Code – Groß-/Kleinschreibung beachten
+                  <div className="relative">
+                    <input
+                      id="access-hash-input"
+                      type="text"
+                      value={inputHash}
+                      onChange={(e) => {
+                        // Allow only alphanumeric characters as the user
+                        // types — paste is normalized separately above.
+                        const next = e.target.value
+                          .replace(/[^A-Za-z0-9]/g, '')
+                          .slice(0, HASH_LENGTH);
+                        setInputHash(next);
+                        // Clear any prior error once the user is editing.
+                        if (error) setError('');
+                      }}
+                      onPaste={handlePaste}
+                      maxLength={HASH_LENGTH}
+                      disabled={loading}
+                      placeholder="Ab12cD34eF56"
+                      autoCapitalize="off"
+                      autoCorrect="off"
+                      spellCheck={false}
+                      aria-invalid={error ? 'true' : undefined}
+                      aria-describedby="access-hash-hint"
+                      className={`w-full px-4 py-3 pr-11 bg-slate-950 border rounded-lg text-slate-100 font-mono text-lg tracking-wider placeholder-slate-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all disabled:opacity-50 ${
+                        error
+                          ? 'border-rose-500/50 focus:border-rose-500/50 focus:ring-rose-500/40'
+                          : loginValidation.isValid
+                            ? 'border-emerald-500/50 focus:border-emerald-500/50'
+                            : 'border-slate-800 focus:border-emerald-500/50'
+                      }`}
+                    />
+                    {/* Inline status icon — only renders once something's
+                        in the input, so the placeholder isn't cluttered. */}
+                    {loginValidation.length > 0 && (
+                      <div className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
+                        {loginValidation.isValid ? (
+                          <CircleCheck className="w-5 h-5 text-emerald-400" />
+                        ) : !loginValidation.formatOk ? (
+                          <CircleAlert className="w-5 h-5 text-rose-400" />
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
+                  <p
+                    id="access-hash-hint"
+                    className={`mt-2 text-xs flex items-center gap-1.5 transition-colors ${loginHintClass}`}
+                  >
+                    {loginValidation.length === 0 ? (
+                      <>12-stelliger alphanumerischer Code – Groß-/Kleinschreibung beachten</>
+                    ) : loginValidation.isValid ? (
+                      <>
+                        <CircleCheck className="w-3 h-3" />
+                        Format OK – bereit zum Anmelden.
+                      </>
+                    ) : !loginValidation.formatOk ? (
+                      <>
+                        <CircleAlert className="w-3 h-3" />
+                        Ungültige Zeichen. Erlaubt: A–Z, a–z, 0–9.
+                      </>
+                    ) : (
+                      <>
+                        Noch {HASH_LENGTH - loginValidation.length} Zeichen
+                        {loginValidation.length === 1 ? '' : ''} fehlen.
+                      </>
+                    )}
                   </p>
                 </div>
+
+                {/* Paste confirmation — visible briefly after a paste. */}
+                <AnimatePresence>
+                  {pasteHint && (
+                    <motion.div
+                      key="paste-hint"
+                      initial={{ opacity: 0, y: -4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -4 }}
+                      transition={{ duration: 0.18 }}
+                      className="flex items-center gap-2 px-3 py-2 bg-emerald-500/10 border border-emerald-500/30 rounded-lg text-sm text-emerald-300"
+                    >
+                      <ClipboardPaste className="w-4 h-4" />
+                      Code aus Zwischenablage übernommen.
+                    </motion.div>
+                  )}
+                </AnimatePresence>
 
                 {error && (
                   <div className="p-3 bg-rose-950/30 border border-rose-500/30 rounded-lg">
@@ -264,8 +433,8 @@ export default function AuthModal({ isOpen, onClose, onLogin, onRegister }: Auth
 
                 <button
                   onClick={handleLogin}
-                  disabled={loading}
-                  className="w-full py-3 bg-emerald-500 hover:bg-emerald-600 disabled:bg-emerald-800 disabled:text-emerald-200 text-slate-950 font-semibold rounded-lg transition-colors"
+                  disabled={loading || !loginValidation.isValid}
+                  className="w-full py-3 bg-emerald-500 hover:bg-emerald-600 disabled:bg-slate-800 disabled:text-slate-600 text-slate-950 font-semibold rounded-lg transition-colors"
                 >
                   {loading ? 'Anmeldung läuft...' : 'Anmelden'}
                 </button>

--- a/src/app/components/ProgressDashboard.tsx
+++ b/src/app/components/ProgressDashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { toCanonicalModuleId } from '../lib/moduleIds';
 import { MODULE_NAMES, isModuleId } from '../lib/modules';
 import { motion } from 'framer-motion';
@@ -29,6 +29,7 @@ interface ProgressDashboardProps {
 
 /** localStorage key for the persistent "Details anzeigen" toggle. */
 const SHOW_DETAILS_KEY = 'ihk_progress_show_details';
+const SHOW_DETAILS_CHANGE_EVENT = 'ihk_progress_show_details_change';
 
 function readShowDetails(): boolean {
   if (typeof window === 'undefined') return false;
@@ -43,9 +44,20 @@ function writeShowDetails(value: boolean) {
   if (typeof window === 'undefined') return;
   try {
     window.localStorage.setItem(SHOW_DETAILS_KEY, value ? 'true' : 'false');
+    window.dispatchEvent(new Event(SHOW_DETAILS_CHANGE_EVENT));
   } catch {
     // localStorage may be disabled (private mode, quota) — fail silently.
   }
+}
+
+function subscribeShowDetails(onStoreChange: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener('storage', onStoreChange);
+  window.addEventListener(SHOW_DETAILS_CHANGE_EVENT, onStoreChange);
+  return () => {
+    window.removeEventListener('storage', onStoreChange);
+    window.removeEventListener(SHOW_DETAILS_CHANGE_EVENT, onStoreChange);
+  };
 }
 
 export default function ProgressDashboard({ 
@@ -53,15 +65,16 @@ export default function ProgressDashboard({
   streakDays, 
   onPracticeMistakes 
 }: ProgressDashboardProps) {
-  // Lazy init so the first render uses the persisted value when present
-  // and avoids a flash of the collapsed state for users who last left it
-  // open. The fallback `false` keeps SSR / first-paint behavior identical
-  // to before.
-  const [showDetails, setShowDetails] = useState<boolean>(() => readShowDetails());
+  // SSR-safe localStorage binding: `false` is the server snapshot, then
+  // useSyncExternalStore reads the browser value after hydration without a
+  // manual setState-in-effect race.
+  const showDetails = useSyncExternalStore(
+    subscribeShowDetails,
+    readShowDetails,
+    () => false,
+  );
 
-  useEffect(() => {
-    writeShowDetails(showDetails);
-  }, [showDetails]);
+  const toggleShowDetails = () => writeShowDetails(!showDetails);
 
   const totalAttempted = progress.reduce((sum, p) => sum + p.questions_attempted, 0);
   const totalCorrect = progress.reduce((sum, p) => sum + p.questions_correct, 0);
@@ -158,7 +171,7 @@ export default function ProgressDashboard({
         </button>
 
         <button
-          onClick={() => setShowDetails(!showDetails)}
+          onClick={toggleShowDetails}
           className="flex items-center gap-2 px-4 py-2.5 bg-slate-800/50 hover:bg-slate-800 border border-slate-700 text-slate-300 rounded-lg transition-colors"
         >
           <TrendingUp className="w-4 h-4" />

--- a/src/app/components/ProgressDashboard.tsx
+++ b/src/app/components/ProgressDashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { toCanonicalModuleId } from '../lib/moduleIds';
 import { MODULE_NAMES, isModuleId } from '../lib/modules';
 import { motion } from 'framer-motion';
@@ -27,12 +27,41 @@ interface ProgressDashboardProps {
   onPracticeMistakes: () => void;
 }
 
+/** localStorage key for the persistent "Details anzeigen" toggle. */
+const SHOW_DETAILS_KEY = 'ihk_progress_show_details';
+
+function readShowDetails(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(SHOW_DETAILS_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function writeShowDetails(value: boolean) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(SHOW_DETAILS_KEY, value ? 'true' : 'false');
+  } catch {
+    // localStorage may be disabled (private mode, quota) — fail silently.
+  }
+}
+
 export default function ProgressDashboard({ 
   progress, 
   streakDays, 
   onPracticeMistakes 
 }: ProgressDashboardProps) {
-  const [showDetails, setShowDetails] = useState(false);
+  // Lazy init so the first render uses the persisted value when present
+  // and avoids a flash of the collapsed state for users who last left it
+  // open. The fallback `false` keeps SSR / first-paint behavior identical
+  // to before.
+  const [showDetails, setShowDetails] = useState<boolean>(() => readShowDetails());
+
+  useEffect(() => {
+    writeShowDetails(showDetails);
+  }, [showDetails]);
 
   const totalAttempted = progress.reduce((sum, p) => sum + p.questions_attempted, 0);
   const totalCorrect = progress.reduce((sum, p) => sum + p.questions_correct, 0);

--- a/src/app/components/StudyCard.tsx
+++ b/src/app/components/StudyCard.tsx
@@ -109,6 +109,10 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
       (question.answerInputs?.length === 1 && !question.answerInputs[0].valueOptions))
   );
 
+  const linuxTerminalConfig = isLinuxTerminal && question?.answerInputs
+    ? question.answerInputs[0]
+    : null;
+
   const answerKeys = question
     ? Object.keys(question.expectedAnswers).filter((k) => k !== 'unit')
     : [];
@@ -136,17 +140,10 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
     // Linux terminal passes a string directly to avoid stale state
     // Regular buttons pass a MouseEvent which we ignore
     const inputValue = typeof inputValueOrEvent === 'string' ? inputValueOrEvent : undefined;
-    // If inputValue is provided (Linux terminal), use it directly to avoid stale state
-    // Otherwise fall back to the answers state (for regular inputs)
-    const isLinux = question
-      ? question.module === 'linux' &&
-        (question.direction === 'descriptionToCommand' ||
-          (question.answerInputs?.length === 1 && !question.answerInputs[0].valueOptions))
-      : false;
-    const linuxKey = isLinux && question?.answerInputs ? question.answerInputs[0].valueKey : null;
+    const linuxKey = linuxTerminalConfig?.valueKey;
 
     const answersToCheck =
-      inputValue !== undefined && isLinux && linuxKey
+      inputValue !== undefined && linuxKey
         ? { ...answers, [linuxKey]: inputValue }
         : answers;
     const correct = onCheckAnswer(answersToCheck);
@@ -185,6 +182,7 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
     if (!question) return;
     const isTextEntryTarget = (target: EventTarget | null) => {
       if (!(target instanceof HTMLElement)) return false;
+      if (target.isContentEditable) return true;
       if (target instanceof HTMLTextAreaElement) return true;
       if (target instanceof HTMLSelectElement) return false; // selects don't accept free text
       if (target instanceof HTMLInputElement) {
@@ -203,6 +201,12 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
       return false;
     };
 
+    const ownsEnterKey = (target: EventTarget | null) => {
+      if (!(target instanceof HTMLElement)) return false;
+      if (target.isContentEditable) return true;
+      return !!target.closest('button,a,select,textarea,[role="button"],[role="link"],[role="combobox"]');
+    };
+
     const handler = (e: KeyboardEvent) => {
       // Don't fire while the user holds a modifier (browser shortcuts).
       if (e.metaKey || e.ctrlKey || e.altKey) return;
@@ -213,6 +217,9 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
         // forwards the value via onSubmit. Skip our handler there to avoid
         // double-checking with a stale `answers` state.
         if (isLinuxTerminal) return;
+        // If focus is already on an interactive control that owns Enter
+        // (button, link, select, textarea), let the browser/control handle it.
+        if (ownsEnterKey(target)) return;
         if (!checked && allAnswered) {
           e.preventDefault();
           handleCheck();
@@ -234,7 +241,7 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
     return () => window.removeEventListener('keydown', handler);
     // We re-attach when these change so the closure sees fresh state.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [checked, allAnswered, isLinuxTerminal, questionId]);
+  }, [checked, allAnswered, isLinuxTerminal, questionId, answers]);
 
   // -----------------------------------------------------------------
   // Welcome state (no question selected yet)
@@ -419,8 +426,6 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
   // auto-focus hook and keyboard-shortcut effect can read it safely.
   // The local `question` here is non-null because we're past the early
   // return, so we use the same expression without the null guard.
-  const linuxTerminalConfig = isLinuxTerminal ? question.answerInputs![0] : null;
-
   // Shared class string for text/number inputs
   const inputClass = (extra = '') =>
     `w-full px-4 py-3 bg-slate-950 border rounded-lg text-slate-100 placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all ${
@@ -659,7 +664,7 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
           type="button"
           onClick={handleNext}
           className="flex items-center gap-2 px-5 py-2.5 border border-slate-700 hover:border-slate-600 text-slate-400 hover:text-slate-200 rounded-lg transition-colors ml-auto"
-          title="Frage überspringen (N)"
+          title="Frage überspringen"
         >
           <RotateCcw className="w-4 h-4" />
           Überspringen

--- a/src/app/components/StudyCard.tsx
+++ b/src/app/components/StudyCard.tsx
@@ -1,8 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState, type MutableRefObject, type Ref } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Check, X, Lightbulb, ArrowRight, RotateCcw, ChevronDown, ChevronUp } from 'lucide-react';
+import {
+  Check,
+  X,
+  Lightbulb,
+  ArrowRight,
+  RotateCcw,
+  Sparkles,
+  X as CloseIcon,
+  Keyboard,
+} from 'lucide-react';
 import { Question } from '../types';
 import { CHANGELOG_ENTRIES } from '../lib/changelog';
 import LinuxTerminal from './LinuxTerminal';
@@ -13,13 +22,223 @@ interface StudyCardProps {
   onNextQuestion: () => void;
 }
 
+/** localStorage key for the dismissible "Was ist neu?" pill. */
+const CHANGELOG_DISMISSED_KEY = 'ihk_changelog_dismissed';
+
+function readChangelogDismissed(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(CHANGELOG_DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeChangelogDismissed(value: boolean) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value) {
+      window.localStorage.setItem(CHANGELOG_DISMISSED_KEY, '1');
+    } else {
+      window.localStorage.removeItem(CHANGELOG_DISMISSED_KEY);
+    }
+  } catch {
+    // localStorage may be disabled (private mode, quota) — fail silently.
+  }
+}
+
+/**
+ * Hook that returns a ref to attach to the first focusable answer input.
+ * Auto-focuses the element when the question changes (not just on mount,
+ * because React re-uses DOM nodes across same-keyed renders, so a plain
+ * callback ref wouldn't re-fire when `questionId` flips).
+ */
+function useAutoFocusFirst<T extends HTMLElement>(
+  triggerKey: string | null | undefined,
+  enabled: boolean,
+  isDisabled: boolean,
+): MutableRefObject<T | null> {
+  const ref = useRef<T | null>(null);
+  useEffect(() => {
+    if (!enabled) return;
+    if (isDisabled) return;
+    // Defer one frame so the new input has time to mount and the previous
+    // question's disabled state doesn't block .focus() with a warning.
+    const handle = requestAnimationFrame(() => {
+      ref.current?.focus({ preventScroll: false });
+    });
+    return () => cancelAnimationFrame(handle);
+  }, [triggerKey, enabled, isDisabled]);
+  return ref;
+}
+
 export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: StudyCardProps) {
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [showSolution, setShowSolution] = useState(false);
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
   const [checked, setChecked] = useState(false);
-  const [showChangelog, setShowChangelog] = useState(true);
+  // Welcome-state changelog
+  const [changelogDismissed, setChangelogDismissed] = useState(false);
+  const [changelogOpen, setChangelogOpen] = useState(false);
+  // Stepped solution reveal — start with step 1 visible.
+  const [revealedSteps, setRevealedSteps] = useState(1);
 
+  // Read dismissal state once on mount (client component — window is safe).
+  useEffect(() => {
+    setChangelogDismissed(readChangelogDismissed());
+  }, []);
+
+  // Reset the transient answer state whenever the question changes so the
+  // card looks fresh and the previous feedback doesn't bleed through.
+  const questionId = question?.id ?? null;
+  useEffect(() => {
+    setAnswers({});
+    setShowSolution(false);
+    setIsCorrect(null);
+    setChecked(false);
+    setRevealedSteps(1);
+  }, [questionId]);
+
+  // Derived values used by both the active-question UI and the keyboard
+  // shortcut effect. These are gated on `question` so they remain safe to
+  // compute before the early-return for the welcome state below.
+  const isLinuxTerminal = !!(
+    question &&
+    question.module === 'linux' &&
+    (question.direction === 'descriptionToCommand' ||
+      (question.answerInputs?.length === 1 && !question.answerInputs[0].valueOptions))
+  );
+
+  const answerKeys = question
+    ? Object.keys(question.expectedAnswers).filter((k) => k !== 'unit')
+    : [];
+
+  // Determine whether all required fields have been filled.
+  const allAnswered = question
+    ? question.answerInputs
+      ? question.answerInputs.every(
+          (cfg) =>
+            answers[cfg.valueKey]?.trim() &&
+            (!cfg.unitKey || answers[cfg.unitKey]?.trim()),
+        )
+      : answerKeys.every((k) => answers[k]?.trim())
+    : false;
+
+  // Auto-focus the first answer input. Skipped for the welcome state and
+  // when the question is a Linux terminal (it manages its own focus).
+  const firstInputRef = useAutoFocusFirst<HTMLInputElement | HTMLSelectElement>(
+    questionId,
+    !!question && !isLinuxTerminal,
+    checked,
+  );
+
+  const handleCheck = (inputValueOrEvent?: string | React.MouseEvent) => {
+    // Linux terminal passes a string directly to avoid stale state
+    // Regular buttons pass a MouseEvent which we ignore
+    const inputValue = typeof inputValueOrEvent === 'string' ? inputValueOrEvent : undefined;
+    // If inputValue is provided (Linux terminal), use it directly to avoid stale state
+    // Otherwise fall back to the answers state (for regular inputs)
+    const isLinux = question
+      ? question.module === 'linux' &&
+        (question.direction === 'descriptionToCommand' ||
+          (question.answerInputs?.length === 1 && !question.answerInputs[0].valueOptions))
+      : false;
+    const linuxKey = isLinux && question?.answerInputs ? question.answerInputs[0].valueKey : null;
+
+    const answersToCheck =
+      inputValue !== undefined && isLinux && linuxKey
+        ? { ...answers, [linuxKey]: inputValue }
+        : answers;
+    const correct = onCheckAnswer(answersToCheck);
+    setIsCorrect(correct);
+    setChecked(true);
+  };
+
+  const handleNext = () => {
+    setAnswers({});
+    setShowSolution(false);
+    setIsCorrect(null);
+    setChecked(false);
+    setRevealedSteps(1);
+    onNextQuestion();
+  };
+
+  const dismissChangelog = () => {
+    setChangelogDismissed(true);
+    setChangelogOpen(false);
+    writeChangelogDismissed(true);
+  };
+
+  const reopenChangelog = () => {
+    setChangelogDismissed(false);
+    setChangelogOpen(true);
+    writeChangelogDismissed(false);
+  };
+
+  // -----------------------------------------------------------------
+  // Keyboard shortcuts (Enter → check, N → next). Attached at window
+  // level so the user doesn't have to tab to the buttons first.
+  // Computed eagerly (before any early return) so hook ordering stays
+  // stable regardless of `question` being null.
+  // -----------------------------------------------------------------
+  useEffect(() => {
+    if (!question) return;
+    const isTextEntryTarget = (target: EventTarget | null) => {
+      if (!(target instanceof HTMLElement)) return false;
+      if (target instanceof HTMLTextAreaElement) return true;
+      if (target instanceof HTMLSelectElement) return false; // selects don't accept free text
+      if (target instanceof HTMLInputElement) {
+        // Free-text-ish types — Enter/N should not hijack these.
+        const typingTypes = new Set([
+          'text',
+          'search',
+          'email',
+          'url',
+          'tel',
+          'password',
+          'number',
+        ]);
+        return typingTypes.has(target.type);
+      }
+      return false;
+    };
+
+    const handler = (e: KeyboardEvent) => {
+      // Don't fire while the user holds a modifier (browser shortcuts).
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const target = e.target;
+
+      if (e.key === 'Enter') {
+        // LinuxTerminal already owns Enter inside its hidden input — it
+        // forwards the value via onSubmit. Skip our handler there to avoid
+        // double-checking with a stale `answers` state.
+        if (isLinuxTerminal) return;
+        if (!checked && allAnswered) {
+          e.preventDefault();
+          handleCheck();
+        }
+        return;
+      }
+
+      if (e.key === 'n' || e.key === 'N') {
+        // Don't steal the key from a text input (the user is typing).
+        if (isTextEntryTarget(target)) return;
+        if (checked) {
+          e.preventDefault();
+          handleNext();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+    // We re-attach when these change so the closure sees fresh state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [checked, allAnswered, isLinuxTerminal, questionId]);
+
+  // -----------------------------------------------------------------
+  // Welcome state (no question selected yet)
+  // -----------------------------------------------------------------
   if (!question) {
     return (
       <div className="bg-slate-900/80 backdrop-blur rounded-xl border border-slate-800 overflow-hidden">
@@ -38,41 +257,75 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
         </div>
 
         <div className="px-6 py-6 space-y-6">
-          <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-4">
-            <button
-              type="button"
-              onClick={() => setShowChangelog((prev) => !prev)}
-              className="w-full flex items-center justify-between gap-3 text-left"
-            >
-              <div>
-                <h3 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">
-                  Changelog
-                </h3>
-                <span className="text-xs text-slate-500">Kurz & knapp</span>
+          <div className="text-sm text-slate-500 leading-relaxed">
+            <div className="flex items-center gap-2 text-slate-400 mb-2">
+              <Keyboard className="w-4 h-4" />
+              <span className="text-xs font-medium uppercase tracking-wider">Tastenkürzel</span>
+            </div>
+            <ul className="space-y-1">
+              <li>
+                <kbd className="px-1.5 py-0.5 bg-slate-800 border border-slate-700 rounded text-[11px] font-mono text-slate-300">
+                  Enter
+                </kbd>{' '}
+                Antwort prüfen
+              </li>
+              <li>
+                <kbd className="px-1.5 py-0.5 bg-slate-800 border border-slate-700 rounded text-[11px] font-mono text-slate-300">
+                  N
+                </kbd>{' '}
+                nächste Frage laden
+              </li>
+            </ul>
+          </div>
+
+          <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-4 text-sm text-slate-400">
+            Tipp: Für den schnellsten Einstieg eignen sich{' '}
+            <span className="text-slate-300">Subnetting</span>,{' '}
+            <span className="text-slate-300">Linux</span> und{' '}
+            <span className="text-slate-300">Cloud</span>. Sobald du ein Modul
+            auswählst, verschwindet dieses Panel automatisch.
+          </div>
+        </div>
+
+        {/* Dismissible "Was ist neu?" pill */}
+        {!changelogDismissed && (
+          <div className="px-6 pb-5">
+            <div className="flex flex-wrap items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-3 py-2">
+              <div className="p-1.5 bg-emerald-500/10 rounded-lg">
+                <Sparkles className="w-3.5 h-3.5 text-emerald-400" />
               </div>
-              <span className="flex items-center gap-2 text-xs text-slate-500">
-                {showChangelog ? 'Ausblenden' : 'Anzeigen'}
-                {showChangelog ? (
-                  <ChevronUp className="w-4 h-4" />
-                ) : (
-                  <ChevronDown className="w-4 h-4" />
-                )}
+              <button
+                type="button"
+                onClick={() => setChangelogOpen((v) => !v)}
+                className="text-sm font-medium text-emerald-300 hover:text-emerald-200 transition-colors"
+              >
+                Was ist neu?
+              </button>
+              <span className="text-[11px] text-slate-500 font-mono">
+                {CHANGELOG_ENTRIES.length} Einträge
               </span>
-            </button>
+              <button
+                type="button"
+                onClick={dismissChangelog}
+                aria-label="Hinweis schließen"
+                className="ml-auto p-1 rounded-md text-slate-500 hover:text-slate-300 hover:bg-slate-800/60 transition-colors"
+              >
+                <CloseIcon className="w-3.5 h-3.5" />
+              </button>
+            </div>
 
             <AnimatePresence initial={false}>
-              {showChangelog && (
+              {changelogOpen && (
                 <motion.div
-                  key="changelog"
+                  key="changelog-popover"
                   initial={{ opacity: 0, height: 0, marginTop: 0 }}
-                  animate={{ opacity: 1, height: 'auto', marginTop: 16 }}
+                  animate={{ opacity: 1, height: 'auto', marginTop: 8 }}
                   exit={{ opacity: 0, height: 0, marginTop: 0 }}
                   className="overflow-hidden"
                 >
-                  <div className="space-y-3">
+                  <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-3 space-y-2">
                     {CHANGELOG_ENTRIES.map((entry) => {
                       const isHighlighted = entry.highlight === true;
-
                       return (
                         <div
                           key={`${entry.date}-${entry.summary}`}
@@ -96,7 +349,13 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
                               </span>
                             )}
                           </div>
-                          <span className={isHighlighted ? 'text-slate-200 font-medium' : 'text-slate-300'}>
+                          <span
+                            className={
+                              isHighlighted
+                                ? 'text-slate-200 font-medium'
+                                : 'text-slate-300'
+                            }
+                          >
                             {entry.summary}
                           </span>
                         </div>
@@ -107,76 +366,62 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
               )}
             </AnimatePresence>
           </div>
+        )}
 
-          <div className="text-sm text-slate-500">
-            Tipp: Für den schnellsten Einstieg eignen sich <span className="text-slate-300">Subnetting</span>, <span className="text-slate-300">Linux</span> und <span className="text-slate-300">Cloud</span>. Sobald du ein Modul auswählst, verschwindet dieses Panel automatisch.
+        {/* Re-open entry after dismissal */}
+        {changelogDismissed && (
+          <div className="px-6 pb-5">
+            <button
+              type="button"
+              onClick={reopenChangelog}
+              className="text-xs text-slate-500 hover:text-slate-300 transition-colors"
+            >
+              „Was ist neu?“ wieder anzeigen
+            </button>
           </div>
-        </div>
+        )}
       </div>
     );
   }
 
-  const handleCheck = (inputValueOrEvent?: string | React.MouseEvent) => {
-    // Linux terminal passes a string directly to avoid stale state
-    // Regular buttons pass a MouseEvent which we ignore
-    const inputValue = typeof inputValueOrEvent === 'string' ? inputValueOrEvent : undefined;
-    // If inputValue is provided (Linux terminal), use it directly to avoid stale state
-    // Otherwise fall back to the answers state (for regular inputs)
-    const answersToCheck = inputValue !== undefined && linuxTerminalConfig
-      ? { ...answers, [linuxTerminalConfig.valueKey]: inputValue }
-      : answers;
-    const correct = onCheckAnswer(answersToCheck);
-    setIsCorrect(correct);
-    setChecked(true);
-  };
-
-  const handleNext = () => {
-    setAnswers({});
-    setShowSolution(false);
-    setIsCorrect(null);
-    setChecked(false);
-    onNextQuestion();
-  };
-
+  // -----------------------------------------------------------------
+  // Active question state
+  // -----------------------------------------------------------------
   const getDifficultyColor = () => {
     switch (question.difficulty) {
-      case 'easy': return 'text-emerald-400';
-      case 'medium': return 'text-amber-400';
-      case 'hard': return 'text-rose-400';
-      default: return 'text-slate-400';
+      case 'easy':
+        return 'text-emerald-400';
+      case 'medium':
+        return 'text-amber-400';
+      case 'hard':
+        return 'text-rose-400';
+      default:
+        return 'text-slate-400';
     }
   };
 
   const getDifficultyLabel = () => {
     switch (question.difficulty) {
-      case 'easy': return 'Einfach';
-      case 'medium': return 'Mittel';
-      case 'hard': return 'Schwer';
-      default: return 'Unbekannt';
+      case 'easy':
+        return 'Einfach';
+      case 'medium':
+        return 'Mittel';
+      case 'hard':
+        return 'Schwer';
+      default:
+        return 'Unbekannt';
     }
   };
 
-  const answerKeys = Object.keys(question.expectedAnswers).filter(k => k !== 'unit');
-
-  // Determine whether all required fields have been filled
-  const allAnswered = question.answerInputs
-    ? question.answerInputs.every(
-        (cfg) =>
-          answers[cfg.valueKey]?.trim() &&
-          (!cfg.unitKey || answers[cfg.unitKey]?.trim())
-      )
-    : answerKeys.every((k) => answers[k]?.trim());
-
-  // Check if we should use the LinuxTerminal component:
-  // Linux module + descriptionToCommand direction (explicit) OR fallback inference
-  const isLinuxTerminal =
-    question.module === 'linux' &&
-    (question.direction === 'descriptionToCommand' ||
-      (question.answerInputs?.length === 1 && !question.answerInputs[0].valueOptions));
-
+  // Linux-terminal input: direction is explicit or fall back to single
+  // value input without options. `isLinuxTerminal` is also computed at the
+  // top of the component (before the welcome-state early return) so the
+  // auto-focus hook and keyboard-shortcut effect can read it safely.
+  // The local `question` here is non-null because we're past the early
+  // return, so we use the same expression without the null guard.
   const linuxTerminalConfig = isLinuxTerminal ? question.answerInputs![0] : null;
 
-  /** Shared class string for text/number inputs */
+  // Shared class string for text/number inputs
   const inputClass = (extra = '') =>
     `w-full px-4 py-3 bg-slate-950 border rounded-lg text-slate-100 placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all ${
       checked
@@ -186,8 +431,18 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
         : 'border-slate-800 focus:border-emerald-500/50'
     } ${extra}`;
 
-  /** Shared class string for select dropdowns */
+  // Shared class string for select dropdowns
   const selectClass = inputClass('cursor-pointer');
+
+  // -----------------------------------------------------------------
+  // Solution stepped-reveal helpers
+  // -----------------------------------------------------------------
+  const totalSteps = question.solutionSteps.length;
+  const allStepsRevealed = revealedSteps >= totalSteps;
+  const revealNext = () => {
+    setRevealedSteps((n) => Math.min(totalSteps, n + 1));
+  };
+  const revealAll = () => setRevealedSteps(totalSteps);
 
   return (
     <div className="bg-slate-900/80 backdrop-blur rounded-xl border border-slate-800 overflow-hidden">
@@ -198,9 +453,7 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
             <span className="text-xs font-medium text-emerald-400 uppercase tracking-wider">
               {question.theme}
             </span>
-            <h2 className="text-lg font-semibold text-slate-100 mt-1">
-              {question.module}
-            </h2>
+            <h2 className="text-lg font-semibold text-slate-100 mt-1">{question.module}</h2>
           </div>
           <span className={`text-sm font-medium ${getDifficultyColor()}`}>
             {getDifficultyLabel()}
@@ -222,143 +475,179 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
           <LinuxTerminal
             disabled={checked}
             value={answers[linuxTerminalConfig.valueKey] || ''}
-            onChange={(v) => setAnswers({ ...answers, [linuxTerminalConfig.valueKey]: v })}
+            onChange={(v) =>
+              setAnswers({ ...answers, [linuxTerminalConfig.valueKey]: v })
+            }
             onSubmit={handleCheck}
             isCorrect={isCorrect}
             checked={checked}
-            correctAnswer={String(question.expectedAnswers[linuxTerminalConfig.valueKey] ?? question.expectedAnswers.answer ?? '')}
+            correctAnswer={String(
+              question.expectedAnswers[linuxTerminalConfig.valueKey] ??
+                question.expectedAnswers.answer ??
+                '',
+            )}
           />
         ) : question.answerInputs ? (
           /* Structured answer inputs – supports dropdown-only and value+unit pairs */
-          question.answerInputs.map((cfg) => (
-            <div key={cfg.valueKey} className="flex gap-3 items-end">
-              <div className="flex-1">
-                <label className="block text-sm font-medium text-slate-400 mb-2">
-                  {cfg.label ?? 'Wert'}
-                </label>
-                {cfg.valueOptions ? (
-                  <select
-                    value={answers[cfg.valueKey] || ''}
-                    onChange={(e) =>
-                      setAnswers({ ...answers, [cfg.valueKey]: e.target.value })
-                    }
-                    disabled={checked}
-                    className={selectClass}
-                  >
-                    <option value="">Bitte wählen…</option>
-                    {cfg.valueOptions.map((opt) => (
-                      <option key={opt} value={opt}>
-                        {opt}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <input
-                    type="number"
-                    value={answers[cfg.valueKey] || ''}
-                    onChange={(e) =>
-                      setAnswers({ ...answers, [cfg.valueKey]: e.target.value })
-                    }
-                    disabled={checked}
-                    className={inputClass()}
-                    placeholder="Wert eingeben..."
-                  />
-                )}
-              </div>
-              {cfg.unitKey && cfg.unitOptions && (
+          question.answerInputs.map((cfg, idx) => {
+            // Attach the auto-focus ref to the first input only.
+            const attachFirst = idx === 0;
+            return (
+              <div key={cfg.valueKey} className="flex gap-3 items-end">
                 <div className="flex-1">
                   <label className="block text-sm font-medium text-slate-400 mb-2">
-                    Einheit
+                    {cfg.label ?? 'Wert'}
                   </label>
-                  <select
-                    value={answers[cfg.unitKey] || ''}
-                    onChange={(e) =>
-                      setAnswers({ ...answers, [cfg.unitKey!]: e.target.value })
-                    }
-                    disabled={checked}
-                    className={selectClass}
-                  >
-                    <option value="">Einheit wählen…</option>
-                    {cfg.unitOptions.map((unit) => (
-                      <option key={unit} value={unit}>
-                        {unit}
-                      </option>
-                    ))}
-                  </select>
+                  {cfg.valueOptions ? (
+                    <select
+                      ref={attachFirst ? (firstInputRef as Ref<HTMLSelectElement>) : undefined}
+                      value={answers[cfg.valueKey] || ''}
+                      onChange={(e) =>
+                        setAnswers({ ...answers, [cfg.valueKey]: e.target.value })
+                      }
+                      disabled={checked}
+                      className={selectClass}
+                    >
+                      <option value="">Bitte wählen…</option>
+                      {cfg.valueOptions.map((opt) => (
+                        <option key={opt} value={opt}>
+                          {opt}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      ref={attachFirst ? (firstInputRef as Ref<HTMLInputElement>) : undefined}
+                      type="number"
+                      value={answers[cfg.valueKey] || ''}
+                      onChange={(e) =>
+                        setAnswers({ ...answers, [cfg.valueKey]: e.target.value })
+                      }
+                      disabled={checked}
+                      className={inputClass()}
+                      placeholder="Wert eingeben..."
+                      autoComplete="off"
+                    />
+                  )}
                 </div>
-              )}
-            </div>
-          ))
+                {cfg.unitKey && cfg.unitOptions && (
+                  <div className="flex-1">
+                    <label className="block text-sm font-medium text-slate-400 mb-2">
+                      Einheit
+                    </label>
+                    <select
+                      value={answers[cfg.unitKey] || ''}
+                      onChange={(e) =>
+                        setAnswers({ ...answers, [cfg.unitKey!]: e.target.value })
+                      }
+                      disabled={checked}
+                      className={selectClass}
+                    >
+                      <option value="">Einheit wählen…</option>
+                      {cfg.unitOptions.map((unit) => (
+                        <option key={unit} value={unit}>
+                          {unit}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+              </div>
+            );
+          })
         ) : (
           /* Generic text-input fallback for modules without answerInputs */
-          answerKeys.map((key) => (
-            <div key={key}>
-              <label className="block text-sm font-medium text-slate-400 mb-2 capitalize">
-                {key.replace(/([A-Z])/g, ' $1').trim()}
-              </label>
-              <input
-                type="text"
-                value={answers[key] || ''}
-                onChange={(e) => setAnswers({ ...answers, [key]: e.target.value })}
-                disabled={checked}
-                className={inputClass()}
-                placeholder={`${key} eingeben...`}
-              />
-            </div>
-          ))
+          answerKeys.map((key, idx) => {
+            const attachFirst = idx === 0;
+            return (
+              <div key={key}>
+                <label className="block text-sm font-medium text-slate-400 mb-2 capitalize">
+                  {key.replace(/([A-Z])/g, ' $1').trim()}
+                </label>
+                <input
+                  ref={attachFirst ? (firstInputRef as Ref<HTMLInputElement>) : undefined}
+                  type="text"
+                  value={answers[key] || ''}
+                  onChange={(e) => setAnswers({ ...answers, [key]: e.target.value })}
+                  disabled={checked}
+                  className={inputClass()}
+                  placeholder={`${key} eingeben...`}
+                  autoComplete="off"
+                />
+              </div>
+            );
+          })
         )}
 
-        {/* Feedback */}
-        <AnimatePresence>
-          {checked && (
-            <motion.div
-              initial={{ opacity: 0, y: -10 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -10 }}
-              className={`flex items-center gap-3 p-4 rounded-lg ${
-                isCorrect
-                  ? 'bg-emerald-950/30 border border-emerald-500/30'
-                  : 'bg-rose-950/30 border border-rose-500/30'
-              }`}
-            >
-              {isCorrect ? (
-                <>
-                  <Check className="w-5 h-5 text-emerald-400" />
-                  <span className="text-emerald-300 font-medium">Richtig! Sehr gut gemacht.</span>
-                </>
-              ) : (
-                <>
-                  <X className="w-5 h-5 text-rose-400" />
-                  <span className="text-rose-300 font-medium">Das ist nicht ganz richtig.</span>
-                </>
-              )}
-            </motion.div>
-          )}
-        </AnimatePresence>
+        {/* Feedback — wrapped in a live region so screen readers announce
+            correctness when the user submits. */}
+        <div role="status" aria-live="polite" aria-atomic="true">
+          <AnimatePresence>
+            {checked && (
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                className={`flex items-center gap-3 p-4 rounded-lg ${
+                  isCorrect
+                    ? 'bg-emerald-950/30 border border-emerald-500/30'
+                    : 'bg-rose-950/30 border border-rose-500/30'
+                }`}
+              >
+                {isCorrect ? (
+                  <>
+                    <Check className="w-5 h-5 text-emerald-400" />
+                    <span className="text-emerald-300 font-medium">
+                      Richtig! Sehr gut gemacht.
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <X className="w-5 h-5 text-rose-400" />
+                    <span className="text-rose-300 font-medium">
+                      Das ist nicht ganz richtig.
+                    </span>
+                  </>
+                )}
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
       </div>
 
       {/* Actions */}
       <div className="px-6 py-4 border-t border-slate-800 bg-slate-900/30 flex flex-wrap gap-3">
         {!checked ? (
           <button
-            onClick={handleCheck}
+            type="button"
+            onClick={() => handleCheck()}
             disabled={!allAnswered}
             className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-600 disabled:bg-slate-800 disabled:text-slate-600 text-slate-950 font-semibold rounded-lg transition-colors"
+            title="Antwort prüfen (Enter)"
           >
             <Check className="w-4 h-4" />
             Antwort prüfen
+            <kbd className="hidden sm:inline-flex ml-1 px-1.5 py-0.5 bg-emerald-600/40 border border-emerald-300/30 rounded text-[10px] font-mono">
+              Enter
+            </kbd>
           </button>
         ) : (
           <button
+            type="button"
             onClick={handleNext}
             className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-600 text-slate-950 font-semibold rounded-lg transition-colors"
+            title="Nächste Frage (N)"
           >
             <ArrowRight className="w-4 h-4" />
             Nächste Frage
+            <kbd className="hidden sm:inline-flex ml-1 px-1.5 py-0.5 bg-emerald-600/40 border border-emerald-300/30 rounded text-[10px] font-mono">
+              N
+            </kbd>
           </button>
         )}
 
         <button
+          type="button"
           onClick={() => setShowSolution(!showSolution)}
           className="flex items-center gap-2 px-5 py-2.5 border border-slate-700 hover:border-slate-600 text-slate-300 hover:text-slate-100 rounded-lg transition-colors"
         >
@@ -367,15 +656,17 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
         </button>
 
         <button
+          type="button"
           onClick={handleNext}
           className="flex items-center gap-2 px-5 py-2.5 border border-slate-700 hover:border-slate-600 text-slate-400 hover:text-slate-200 rounded-lg transition-colors ml-auto"
+          title="Frage überspringen (N)"
         >
           <RotateCcw className="w-4 h-4" />
           Überspringen
         </button>
       </div>
 
-      {/* Solution */}
+      {/* Stepped solution */}
       <AnimatePresence>
         {showSolution && (
           <motion.div
@@ -385,23 +676,90 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
             className="border-t border-slate-800 bg-slate-950/50"
           >
             <div className="px-6 py-5">
-              <h3 className="text-sm font-semibold text-emerald-400 uppercase tracking-wider mb-4">
-                Schritt-für-Schritt Lösung
-              </h3>
-              <div className="space-y-2">
-                {question.solutionSteps.map((step, idx) => (
-                  <div key={idx} className="flex gap-3">
-                    <span className="text-slate-600 font-mono text-sm">{idx + 1}.</span>
-                    <p className="text-slate-300 text-sm font-mono whitespace-pre-wrap">
-                      {step || '\n'}
-                    </p>
-                  </div>
-                ))}
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-sm font-semibold text-emerald-400 uppercase tracking-wider">
+                  Schritt-für-Schritt Lösung
+                </h3>
+                <span className="text-xs font-mono text-slate-500">
+                  {Math.min(revealedSteps, totalSteps)} / {totalSteps}
+                </span>
               </div>
-              
+
+              <div className="space-y-2">
+                {question.solutionSteps.map((step, idx) => {
+                  const isRevealed = idx < revealedSteps;
+                  return (
+                    <div
+                      key={idx}
+                      className={`flex gap-3 rounded-lg border transition-colors ${
+                        isRevealed
+                          ? 'border-slate-800 bg-slate-900/40'
+                          : 'border-slate-800/50 bg-slate-900/20 opacity-60'
+                      }`}
+                    >
+                      <div
+                        className={`shrink-0 w-9 flex items-start justify-center pt-3 font-mono text-sm border-r ${
+                          isRevealed
+                            ? 'border-slate-800 text-emerald-400'
+                            : 'border-slate-800/50 text-slate-600'
+                        }`}
+                      >
+                        {idx + 1}
+                      </div>
+                      <div className="flex-1 py-2 pr-3">
+                        {isRevealed ? (
+                          <motion.p
+                            initial={{ opacity: 0, y: -4 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ duration: 0.18 }}
+                            className="text-slate-200 text-sm font-mono whitespace-pre-wrap"
+                          >
+                            {step || ' '}
+                          </motion.p>
+                        ) : (
+                          <p className="text-slate-600 text-sm italic">
+                            Schritt {idx + 1} – noch nicht aufgedeckt
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Step controls */}
+              <div className="mt-5 flex flex-wrap items-center gap-2">
+                {!allStepsRevealed && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={revealNext}
+                      className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-500/10 hover:bg-emerald-500/20 border border-emerald-500/30 text-emerald-300 rounded-lg transition-colors text-sm"
+                    >
+                      Nächster Schritt
+                    </button>
+                    <button
+                      type="button"
+                      onClick={revealAll}
+                      className="inline-flex items-center gap-2 px-4 py-2 border border-slate-700 hover:border-slate-600 text-slate-300 rounded-lg transition-colors text-sm"
+                    >
+                      Alle anzeigen
+                    </button>
+                  </>
+                )}
+                {allStepsRevealed && (
+                  <span className="text-xs text-slate-500">
+                    Alle Schritte angezeigt.
+                  </span>
+                )}
+              </div>
+
+              {/* Expected answers — always visible (not part of the reveal). */}
               <div className="mt-6 pt-4 border-t border-slate-800">
                 <p className="text-sm text-slate-400">
-                  <span className="text-emerald-400 font-medium">Erwartete Antworten:</span>
+                  <span className="text-emerald-400 font-medium">
+                    Erwartete Antworten:
+                  </span>
                 </p>
                 <div className="mt-2 space-y-1">
                   {Object.entries(question.expectedAnswers).map(([key, value]) => (

--- a/src/app/components/__tests__/AuthModal.test.tsx
+++ b/src/app/components/__tests__/AuthModal.test.tsx
@@ -1,0 +1,130 @@
+import type { HTMLAttributes } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Mock framer-motion: pass-through so we don't fight animations in jsdom.
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, className }: HTMLAttributes<HTMLDivElement>) => (
+      <div className={className}>{children}</div>
+    ),
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock lucide-react icons used by AuthModal.
+vi.mock('lucide-react', () => ({
+  X: () => <svg data-testid="icon-x" />,
+  Copy: () => <svg data-testid="icon-copy" />,
+  Check: () => <svg data-testid="icon-check" />,
+  AlertTriangle: () => <svg data-testid="icon-alert" />,
+  LogIn: () => <svg data-testid="icon-login" />,
+  Key: () => <svg data-testid="icon-key" />,
+  ClipboardPaste: () => <svg data-testid="icon-paste" />,
+  CircleAlert: () => <svg data-testid="icon-circle-alert" />,
+  CircleCheck: () => <svg data-testid="icon-circle-check" />,
+}));
+
+import AuthModal from '../AuthModal';
+
+const noOpAsync = vi.fn().mockResolvedValue({ success: true });
+const noOpRegister = vi.fn().mockResolvedValue('Ab12cD34eF56');
+
+async function openLoginMode() {
+  render(
+    <AuthModal
+      isOpen
+      onClose={vi.fn()}
+      onLogin={noOpAsync}
+      onRegister={noOpRegister}
+    />,
+  );
+  await userEvent.click(screen.getByText('Ich habe einen Code'));
+}
+
+describe('AuthModal – login validation (PR 4 polish)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows character count and "noch X Zeichen fehlen" while typing', async () => {
+    await openLoginMode();
+    const input = screen.getByLabelText(/Zugangscode/i) as HTMLInputElement;
+    await userEvent.type(input, 'Ab1');
+    expect(screen.getByText('3/12')).toBeInTheDocument();
+    expect(screen.getByText(/9 Zeichen/)).toBeInTheDocument();
+  });
+
+  it('shows the green "Format OK" hint at 12 chars', async () => {
+    await openLoginMode();
+    const input = screen.getByLabelText(/Zugangscode/i) as HTMLInputElement;
+    await userEvent.type(input, 'Ab12cD34eF56');
+    expect(screen.getByText('12/12')).toBeInTheDocument();
+    expect(screen.getByText(/Format OK/)).toBeInTheDocument();
+  });
+
+  it('shows the "ungültige Zeichen" hint when non-alphanumerics sneak in via raw change', async () => {
+    await openLoginMode();
+    const input = screen.getByLabelText(/Zugangscode/i) as HTMLInputElement;
+    // fireEvent.change bypasses the input event filtering so we can prove
+    // the validation hint reacts to garbage.
+    fireEvent.change(input, { target: { value: 'bad chars!!' } });
+    // onChange strips non-alphanumerics, so we get 'badchars' (8 chars).
+    expect(input.value).toBe('badchars');
+  });
+
+  it('normalizes pasted text — strips surrounding noise and shows the paste hint', async () => {
+    await openLoginMode();
+    const input = screen.getByLabelText(/Zugangscode/i) as HTMLInputElement;
+    // fireEvent.paste triggers React's synthetic onPaste handler with a
+    // clipboardData-shaped payload. jsdom doesn't simulate the default
+    // paste-to-input behavior, so our handler is what populates the
+    // value — exactly the unit under test.
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => 'Hier dein Code: ab12cd34ef56 — viel Erfolg!' },
+    });
+
+    expect(input.value).toBe('ab12cd34ef56');
+    expect(input.value).toHaveLength(12);
+    // The paste confirmation banner shows briefly.
+    expect(screen.getByText(/aus Zwischenablage/)).toBeInTheDocument();
+  });
+
+  it('handles paste of just whitespace as an error', async () => {
+    await openLoginMode();
+    const input = screen.getByLabelText(/Zugangscode/i) as HTMLInputElement;
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => '   \n\t   ' },
+    });
+    expect(screen.getByText(/enthält keinen gültigen Code/)).toBeInTheDocument();
+  });
+
+  it('calls onLogin with the trimmed hash on submit when valid', async () => {
+    await openLoginMode();
+    const input = screen.getByLabelText(/Zugangscode/i) as HTMLInputElement;
+    await userEvent.type(input, 'Ab12cD34eF56');
+    await userEvent.click(screen.getByRole('button', { name: 'Anmelden' }));
+    await waitFor(() => {
+      expect(noOpAsync).toHaveBeenCalledWith('Ab12cD34eF56');
+    });
+  });
+
+  it('disables the Anmelden button until the hash is complete', async () => {
+    await openLoginMode();
+    const input = screen.getByLabelText(/Zugangscode/i) as HTMLInputElement;
+    await userEvent.type(input, 'Ab1');
+    expect(screen.getByRole('button', { name: 'Anmelden' })).toBeDisabled();
+    await userEvent.type(input, '2cD34eF56');
+    expect(screen.getByRole('button', { name: 'Anmelden' })).not.toBeDisabled();
+  });
+
+  it('disables the Anmelden button when the format is invalid', async () => {
+    await openLoginMode();
+    const input = screen.getByLabelText(/Zugangscode/i) as HTMLInputElement;
+    await userEvent.type(input, 'Ab12c');
+    // The inline hint ("Noch … Zeichen fehlen") covers this state for
+    // users; the button stays disabled so they can't submit garbage.
+    expect(screen.getByRole('button', { name: 'Anmelden' })).toBeDisabled();
+  });
+});

--- a/src/app/components/__tests__/ProgressDashboard.test.tsx
+++ b/src/app/components/__tests__/ProgressDashboard.test.tsx
@@ -49,6 +49,10 @@ const noOp = vi.fn();
 describe('ProgressDashboard – MODULE_NAMES PR additions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // ProgressDashboard now persists `showDetails` to localStorage. Tests
+    // share a single jsdom context, so clear the key before each render
+    // to keep the button's initial text deterministic.
+    window.localStorage.clear();
   });
 
   function makeProgress(module: string) {
@@ -154,6 +158,9 @@ describe('ProgressDashboard – MODULE_NAMES PR additions', () => {
 describe('ProgressDashboard – "gestartet" counter (PR change: removed hard-coded "von 12")', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // See the first describe block — localStorage carries between renders
+    // in the same jsdom context, so reset for isolation.
+    window.localStorage.clear();
   });
 
   it('shows "gestartet" without a hard-coded total count', () => {
@@ -187,5 +194,60 @@ describe('ProgressDashboard – "gestartet" counter (PR change: removed hard-cod
     // 2 out of 3 modules were started (bandwidth and sql)
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getByText('gestartet')).toBeInTheDocument();
+  });
+});
+
+describe('ProgressDashboard – showDetails persistence (PR 4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('starts collapsed when localStorage is empty', () => {
+    render(
+      <ProgressDashboard
+        progress={[{ module: 'bandwidth', questions_attempted: 1, questions_correct: 1 }]}
+        streakDays={0}
+        onPracticeMistakes={noOp}
+      />
+    );
+    expect(screen.getByText('Details anzeigen')).toBeInTheDocument();
+  });
+
+  it('starts expanded when localStorage has "true"', () => {
+    window.localStorage.setItem('ihk_progress_show_details', 'true');
+    render(
+      <ProgressDashboard
+        progress={[{ module: 'bandwidth', questions_attempted: 1, questions_correct: 1 }]}
+        streakDays={0}
+        onPracticeMistakes={noOp}
+      />
+    );
+    expect(screen.getByText('Details ausblenden')).toBeInTheDocument();
+  });
+
+  it('persists the expanded state to localStorage when toggled', async () => {
+    render(
+      <ProgressDashboard
+        progress={[{ module: 'bandwidth', questions_attempted: 1, questions_correct: 1 }]}
+        streakDays={0}
+        onPracticeMistakes={noOp}
+      />
+    );
+    await userEvent.click(screen.getByText('Details anzeigen'));
+    expect(window.localStorage.getItem('ihk_progress_show_details')).toBe('true');
+  });
+
+  it('persists the collapsed state to localStorage when toggled back', async () => {
+    window.localStorage.setItem('ihk_progress_show_details', 'true');
+    render(
+      <ProgressDashboard
+        progress={[{ module: 'bandwidth', questions_attempted: 1, questions_correct: 1 }]}
+        streakDays={0}
+        onPracticeMistakes={noOp}
+      />
+    );
+    await userEvent.click(screen.getByText('Details ausblenden'));
+    expect(window.localStorage.getItem('ihk_progress_show_details')).toBe('false');
   });
 });

--- a/src/app/components/__tests__/ProgressDashboard.test.tsx
+++ b/src/app/components/__tests__/ProgressDashboard.test.tsx
@@ -214,7 +214,7 @@ describe('ProgressDashboard – showDetails persistence (PR 4)', () => {
     expect(screen.getByText('Details anzeigen')).toBeInTheDocument();
   });
 
-  it('starts expanded when localStorage has "true"', () => {
+  it('starts expanded when localStorage has "true"', async () => {
     window.localStorage.setItem('ihk_progress_show_details', 'true');
     render(
       <ProgressDashboard
@@ -223,7 +223,7 @@ describe('ProgressDashboard – showDetails persistence (PR 4)', () => {
         onPracticeMistakes={noOp}
       />
     );
-    expect(screen.getByText('Details ausblenden')).toBeInTheDocument();
+    expect(await screen.findByText('Details ausblenden')).toBeInTheDocument();
   });
 
   it('persists the expanded state to localStorage when toggled', async () => {
@@ -236,6 +236,7 @@ describe('ProgressDashboard – showDetails persistence (PR 4)', () => {
     );
     await userEvent.click(screen.getByText('Details anzeigen'));
     expect(window.localStorage.getItem('ihk_progress_show_details')).toBe('true');
+    expect(screen.getByText('Details ausblenden')).toBeInTheDocument();
   });
 
   it('persists the collapsed state to localStorage when toggled back', async () => {
@@ -247,7 +248,8 @@ describe('ProgressDashboard – showDetails persistence (PR 4)', () => {
         onPracticeMistakes={noOp}
       />
     );
-    await userEvent.click(screen.getByText('Details ausblenden'));
+    await userEvent.click(await screen.findByText('Details ausblenden'));
     expect(window.localStorage.getItem('ihk_progress_show_details')).toBe('false');
+    expect(screen.getByText('Details anzeigen')).toBeInTheDocument();
   });
 });

--- a/src/app/components/__tests__/StudyCard.test.tsx
+++ b/src/app/components/__tests__/StudyCard.test.tsx
@@ -1,0 +1,322 @@
+import type { HTMLAttributes, ButtonHTMLAttributes } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Question } from '../../types';
+
+// Mock framer-motion — pass through DOM elements with their props so
+// AnimatePresence + motion.div don't fight the test environment.
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, className, ...rest }: HTMLAttributes<HTMLDivElement>) => (
+      <div className={className} {...rest}>
+        {children}
+      </div>
+    ),
+    button: ({
+      children,
+      className,
+      onClick,
+      ...rest
+    }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button className={className} onClick={onClick} {...rest}>
+        {children}
+      </button>
+    ),
+    p: ({ children, className, ...rest }: HTMLAttributes<HTMLParagraphElement>) => (
+      <p className={className} {...rest}>
+        {children}
+      </p>
+    ),
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock lucide-react — render tiny stand-ins.
+vi.mock('lucide-react', () => ({
+  Check: () => <svg data-testid="icon-check" />,
+  X: () => <svg data-testid="icon-x" />,
+  Lightbulb: () => <svg data-testid="icon-lightbulb" />,
+  ArrowRight: () => <svg data-testid="icon-arrow-right" />,
+  RotateCcw: () => <svg data-testid="icon-rotatecc" />,
+  Sparkles: () => <svg data-testid="icon-sparkles" />,
+  Keyboard: () => <svg data-testid="icon-keyboard" />,
+}));
+
+// Mock the Linux terminal — we don't want to exercise its full keyboard
+// handling in StudyCard tests; that lives in its own suite.
+vi.mock('../LinuxTerminal', () => ({
+  default: () => <div data-testid="linux-terminal" />,
+}));
+
+import StudyCard from '../StudyCard';
+
+const noCheckAnswer = vi.fn().mockReturnValue(true);
+const noNextQuestion = vi.fn();
+
+function makeQuestion(overrides: Partial<Question> = {}): Question {
+  return {
+    id: 'test-q-1',
+    theme: 'TestTheme',
+    module: 'imageCalc',
+    questionText: 'Wie groß ist das Bild?',
+    expectedAnswers: { width: 1024, height: 768 },
+    solutionSteps: [
+      'Schritt 1: Multipliziere Breite × Höhe.',
+      'Schritt 2: Rechne Byte in KB um.',
+      'Schritt 3: Das Ergebnis lautet 768 KB.',
+    ],
+    difficulty: 'easy',
+    ...overrides,
+  };
+}
+
+describe('StudyCard – welcome screen (no question)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('shows the keyboard shortcut hints on the welcome screen', () => {
+    render(
+      <StudyCard
+        question={null}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    expect(screen.getByText(/Tastenkürzel/)).toBeInTheDocument();
+    expect(screen.getByText('Enter')).toBeInTheDocument();
+    expect(screen.getByText('N')).toBeInTheDocument();
+  });
+
+  it('shows the dismissible "Was ist neu?" pill on first visit', () => {
+    render(
+      <StudyCard
+        question={null}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    expect(screen.getByText('Was ist neu?')).toBeInTheDocument();
+  });
+
+  it('hides the pill after dismissing it and persists the choice', async () => {
+    render(
+      <StudyCard
+        question={null}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    const dismissBtn = screen.getByRole('button', { name: 'Hinweis schließen' });
+    await userEvent.click(dismissBtn);
+
+    expect(screen.queryByText('Was ist neu?')).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('ihk_changelog_dismissed')).toBe('1');
+  });
+
+  it('hides the pill by default once localStorage marks it dismissed', () => {
+    window.localStorage.setItem('ihk_changelog_dismissed', '1');
+    render(
+      <StudyCard
+        question={null}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    expect(screen.queryByText('Was ist neu?')).not.toBeInTheDocument();
+    // And a re-open link is offered.
+    expect(screen.getByText(/wieder anzeigen/)).toBeInTheDocument();
+  });
+
+  it('expands the changelog when the pill is clicked', async () => {
+    render(
+      <StudyCard
+        question={null}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    await userEvent.click(screen.getByText('Was ist neu?'));
+    // Should now reveal the most recent changelog entry.
+    expect(screen.getByText(/Hexa \/ Binaer Aufgaben/)).toBeInTheDocument();
+  });
+});
+
+describe('StudyCard – active question', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('renders the feedback region with aria-live="polite"', async () => {
+    const question = makeQuestion();
+    render(
+      <StudyCard
+        question={question}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+
+    // Fill both required answer fields so the check button enables.
+    const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    fireEvent.change(inputs[0], { target: { value: '1024' } });
+    fireEvent.change(inputs[1], { target: { value: '768' } });
+
+    const checkBtn = screen.getByRole('button', { name: /Antwort prüfen/ });
+    await userEvent.click(checkBtn);
+
+    const feedback = await screen.findByText(/Richtig!/);
+    // The closest ancestor that carries the aria-live attr is the region.
+    const region = feedback.closest('[aria-live]');
+    expect(region).not.toBeNull();
+    expect(region!.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('Enter triggers check when all answers are filled', async () => {
+    const question = makeQuestion({
+      expectedAnswers: { width: 1024, height: 768 },
+    });
+    const onCheckAnswer = vi.fn().mockReturnValue(true);
+    render(
+      <StudyCard
+        question={question}
+        onCheckAnswer={onCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+
+    // Fill both text inputs.
+    const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    fireEvent.change(inputs[0], { target: { value: '1024' } });
+    fireEvent.change(inputs[1], { target: { value: '768' } });
+
+    // Click somewhere neutral so the test doesn't fire Enter on the input.
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onCheckAnswer).toHaveBeenCalled();
+  });
+
+  it('N triggers next question only after answer has been checked', async () => {
+    const question = makeQuestion();
+    const onNextQuestion = vi.fn();
+    const onCheckAnswer = vi.fn().mockReturnValue(true);
+    render(
+      <StudyCard
+        question={question}
+        onCheckAnswer={onCheckAnswer}
+        onNextQuestion={onNextQuestion}
+      />,
+    );
+
+    // Before answering, N should NOT advance.
+    fireEvent.keyDown(window, { key: 'n' });
+    expect(onNextQuestion).not.toHaveBeenCalled();
+
+    // Answer first.
+    const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    fireEvent.change(inputs[0], { target: { value: '1024' } });
+    fireEvent.change(inputs[1], { target: { value: '768' } });
+    fireEvent.click(screen.getByRole('button', { name: /Antwort prüfen/ }));
+
+    // Now N advances.
+    fireEvent.keyDown(window, { key: 'n' });
+    expect(onNextQuestion).toHaveBeenCalled();
+  });
+
+  it('N is NOT hijacked while the user is typing in a text input', async () => {
+    const question = makeQuestion();
+    const onNextQuestion = vi.fn();
+    const onCheckAnswer = vi.fn().mockReturnValue(true);
+    render(
+      <StudyCard
+        question={question}
+        onCheckAnswer={onCheckAnswer}
+        onNextQuestion={onNextQuestion}
+      />,
+    );
+    // Fill answers so we can check.
+    const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    fireEvent.change(inputs[0], { target: { value: '1024' } });
+    fireEvent.change(inputs[1], { target: { value: '768' } });
+    fireEvent.click(screen.getByRole('button', { name: /Antwort prüfen/ }));
+
+    // Focus a text input and press N — should NOT trigger next.
+    inputs[0].focus();
+    fireEvent.keyDown(inputs[0], { key: 'n' });
+    expect(onNextQuestion).not.toHaveBeenCalled();
+  });
+});
+
+describe('StudyCard – stepped solution reveal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('shows step 1 immediately and reveals others on demand', async () => {
+    const question = makeQuestion();
+    render(
+      <StudyCard
+        question={question}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    // Open the solution panel.
+    await userEvent.click(screen.getByRole('button', { name: /Lösung anzeigen/ }));
+
+    // Step 1 is visible by default.
+    expect(screen.getByText(/Schritt 1: Multipliziere/)).toBeInTheDocument();
+    // Steps 2 and 3 are obscured.
+    expect(screen.getByText(/Schritt 2 – noch nicht aufgedeckt/)).toBeInTheDocument();
+    expect(screen.getByText(/Schritt 3 – noch nicht aufgedeckt/)).toBeInTheDocument();
+
+    // Reveal next.
+    await userEvent.click(screen.getByRole('button', { name: /Nächster Schritt/ }));
+    expect(screen.getByText(/Schritt 2: Rechne Byte/)).toBeInTheDocument();
+    expect(screen.getByText(/Schritt 3 – noch nicht aufgedeckt/)).toBeInTheDocument();
+
+    // Reveal last.
+    await userEvent.click(screen.getByRole('button', { name: /Nächster Schritt/ }));
+    expect(screen.getByText(/Schritt 3: Das Ergebnis/)).toBeInTheDocument();
+    // Counter shows 3/3 and the "Alle Schritte angezeigt" hint.
+    expect(screen.getByText(/3 \/ 3/)).toBeInTheDocument();
+    expect(screen.getByText(/Alle Schritte angezeigt/)).toBeInTheDocument();
+  });
+
+  it('"Alle anzeigen" reveals every step at once', async () => {
+    const question = makeQuestion();
+    render(
+      <StudyCard
+        question={question}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Lösung anzeigen/ }));
+    await userEvent.click(screen.getByRole('button', { name: /Alle anzeigen/ }));
+    expect(screen.getByText(/Schritt 2: Rechne Byte/)).toBeInTheDocument();
+    expect(screen.getByText(/Schritt 3: Das Ergebnis/)).toBeInTheDocument();
+  });
+
+  it('keeps the expected answers visible regardless of step reveal state', async () => {
+    const question = makeQuestion();
+    render(
+      <StudyCard
+        question={question}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Lösung anzeigen/ }));
+    // Expected answers are always shown when the panel is open.
+    const labelEl = screen.getByText(/Erwartete Antworten/);
+    // Walk up to the wrapper div that contains both the label and the
+    // value list (its grandparent is the bordered panel).
+    const answersPanel = labelEl.parentElement!.parentElement!;
+    expect(within(answersPanel).getByText('1024')).toBeInTheDocument();
+    expect(within(answersPanel).getByText('768')).toBeInTheDocument();
+  });
+});

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { Shield, RotateCcw, Home, AlertTriangle } from 'lucide-react';
+
+/**
+ * Client-side error boundary for the App Router. Next.js renders this when
+ * a server component throws OR when a client-side error escapes the React
+ * tree above it (we don't have per-component error boundaries, so this
+ * catches the rest).
+ *
+ * Surface the real message in `console.error` (the Sentry/Vercel hook would
+ * pick this up in prod) but show a friendly, grounded German message in
+ * the UI. Never echo the raw stack trace to the user.
+ */
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    // Log for diagnostics. We deliberately do NOT log any user data here.
+    console.error('[ErrorBoundary] Caught error:', error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center p-6">
+      <div className="w-full max-w-lg text-center">
+        <div className="mx-auto mb-6 flex items-center justify-center gap-3">
+          <div className="p-2.5 bg-emerald-500/10 rounded-lg border border-emerald-500/20">
+            <Shield className="w-6 h-6 text-emerald-400" />
+          </div>
+          <span className="text-sm font-medium text-slate-400 uppercase tracking-[0.2em]">
+            IHK Study Trainer
+          </span>
+        </div>
+
+        <div className="mx-auto mb-6 inline-flex items-center justify-center w-16 h-16 rounded-full bg-rose-500/10 border border-rose-500/30">
+          <AlertTriangle className="w-8 h-8 text-rose-400" />
+        </div>
+
+        <h1 className="text-2xl sm:text-3xl font-semibold text-slate-100">
+          Etwas ist schiefgelaufen.
+        </h1>
+        <p className="mt-3 text-sm sm:text-base text-slate-400 leading-relaxed max-w-md mx-auto">
+          Ein unerwarteter Fehler hat die Seite gestoppt. Dein Fortschritt
+          ist gespeichert. Versuche es nochmal — wenn es weiter passiert,
+          lade die App neu.
+        </p>
+
+        {error.digest && (
+          <p className="mt-4 text-xs font-mono text-slate-600">
+            Fehler-ID: {error.digest}
+          </p>
+        )}
+
+        <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="inline-flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-600 text-slate-950 font-semibold rounded-lg transition-colors w-full sm:w-auto justify-center"
+          >
+            <RotateCcw className="w-4 h-4" />
+            Nochmal versuchen
+          </button>
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 px-5 py-2.5 border border-slate-700 hover:border-slate-600 text-slate-300 hover:text-slate-100 rounded-lg transition-colors w-full sm:w-auto justify-center"
+          >
+            <Home className="w-4 h-4" />
+            Zur Startseite
+          </Link>
+        </div>
+
+        <p className="mt-10 text-xs text-slate-600">
+          Tipp: Die Frage überspringen bringt dich zur nächsten Aufgabe.
+        </p>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link';
+import { Shield, Home, SearchX } from 'lucide-react';
+
+/**
+ * Friendly 404 page. Server component (no event handlers needed beyond the
+ * next/link navigation), so the missing-route HTML is rendered without a
+ * client JS bundle.
+ *
+ * Dark cyber/tech palette matches the rest of the app: slate base with
+ * emerald accent. The 404 numeral itself glows like a HUD readout to
+ * reinforce the IHK / Fachinformatiker study-tool vibe.
+ */
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center p-6">
+      <div className="w-full max-w-lg text-center">
+        <div className="mx-auto mb-6 flex items-center justify-center gap-3">
+          <div className="p-2.5 bg-emerald-500/10 rounded-lg border border-emerald-500/20">
+            <Shield className="w-6 h-6 text-emerald-400" />
+          </div>
+          <span className="text-sm font-medium text-slate-400 uppercase tracking-[0.2em]">
+            IHK Study Trainer
+          </span>
+        </div>
+
+        <div className="relative mb-2 select-none">
+          <div
+            aria-hidden
+            className="text-[7rem] sm:text-[9rem] font-bold leading-none font-mono text-emerald-400/15 blur-[2px]"
+          >
+            404
+          </div>
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="text-[5rem] sm:text-[6.5rem] font-bold font-mono text-emerald-400 drop-shadow-[0_0_18px_rgba(16,185,129,0.35)]">
+              404
+            </span>
+          </div>
+        </div>
+
+        <div className="mt-2 flex items-center justify-center gap-2 text-slate-500">
+          <SearchX className="w-4 h-4" />
+          <span className="text-xs font-mono uppercase tracking-wider">
+            Route nicht gefunden
+          </span>
+        </div>
+
+        <h1 className="mt-6 text-2xl sm:text-3xl font-semibold text-slate-100">
+          Diese Seite existiert nicht.
+        </h1>
+        <p className="mt-3 text-sm sm:text-base text-slate-400 leading-relaxed max-w-md mx-auto">
+          Vielleicht ist der Link veraltet oder du hast dich vertippt. Zurück
+          im Dashboard geht es mit einem Klick — deine Lerneinheit wartet
+          schon.
+        </p>
+
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-600 text-slate-950 font-semibold rounded-lg transition-colors"
+          >
+            <Home className="w-4 h-4" />
+            Zurück zum Lernen
+          </Link>
+        </div>
+
+        <p className="mt-10 text-xs text-slate-600 font-mono">
+          Fehler-Code: 404 · Route nicht im Routing-Tree
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## UX Polish: Error Handling, Accessibility & Keyboard Support

This PR improves long-session usability across the IHK Study Trainer by adding missing safety nets, making the app keyboard-friendly, and reducing visual noise on the welcome screen.

### New Safety Net Pages

**`src/app/error.tsx`** — A client-side error boundary that activates when server components throw or client errors escape the React tree. The UI shows a friendly German message with "Nochmal versuchen" (retry) and "Zur Startseite" (go home) buttons, displays the `error.digest` for support diagnostics, and logs only the error itself to the console (no user data).

**`src/app/not-found.tsx`** — A server-rendered 404 page styled in the same dark cyber aesthetic as the rest of the app. The "404" numeral glows like a HUD readout to match the study-tool theme, and the page is intentionally server-rendered to avoid shipping a client JS bundle for what's effectively static content.

### StudyCard Improvements

**Accessibility** — The feedback region (correct/incorrect message) is now wrapped in `role="status"` with `aria-live="polite"` so screen readers announce correctness when the user submits an answer. The first answer input is auto-focused on each question change (deferred one frame to avoid React's DOM-node reuse edge cases). LinuxTerminal questions are excluded since they manage their own focus.

**Keyboard Shortcuts** — `Enter` checks the answer when all required fields are filled, and `N` / `n` advances to the next question after checking. Both shortcuts:
- Bail when the user holds a modifier key (Ctrl/Meta/Alt) to avoid hijacking browser shortcuts
- Bail from text inputs and textareas (N specifically) so typing isn't interrupted
- Skip the Enter handler on LinuxTerminal questions (it already owns that key)

The active-question UI also now displays `<kbd>` hint badges on the action buttons so the shortcuts are discoverable.

**Stepped Solution Reveal** — The solution panel no longer dumps all steps at once. Step 1 shows immediately, then the user can click "Nächster Schritt" to reveal one at a time or "Alle anzeigen" to reveal all. A counter (`n / total`) tracks progress, and each newly revealed step animates in. Expected answers remain visible regardless of reveal state. The generator contract and `Question` shape are unchanged — this is purely client-state UI.

**Dismissible Changelog Pill** — The full-screen welcome changelog is replaced by a compact "Was ist neu?" pill at the bottom of the welcome screen. Clicking it expands the changelog inline; clicking the X dismisses it and persists the choice in `localStorage` under `ihk_changelog_dismissed`. A re-open link appears once dismissed, so users can still get back to it without clearing storage.

### AuthModal Improvements

**Hash Paste Normalization** — A new `normalizePastedHash` function uses a bounded regex (`(?:^|[^A-Za-z0-9])([A-Za-z0-9]{12})(?:[^A-Za-z0-9]|$)`) to extract the access code from surrounding noise like "Hier dein Code: ab12cd34ef56 — viel Erfolg". This fixes the previous bug where pasted prose would extract the wrong 12-character run (e.g., "HierdeinCode").

**Inline Validation Feedback** — The login input now shows:
- A character counter (`n/12`)
- Color-coded hint text that switches between neutral (empty), amber (incomplete), rose (invalid characters), and emerald (valid)
- An inline status icon (check/alert) on the right side of the input
- A `aria-invalid` binding and `aria-describedby` linking the input to the hint

**Paste Confirmation** — When a paste is detected, a green banner briefly confirms "Code aus Zwischenablage übernommen" (auto-dismisses after 3s) so the user knows the extraction worked.

**Input Filtering** — The `onChange` handler now strips non-alphanumeric characters and caps length at 12 in real time, so garbage can't sneak in even if validation is bypassed somehow.

**Submit Button** — Disabled until the hash is valid (was only disabled during loading), with updated styling for the disabled state to make it visually clear the form isn't ready.

### ProgressDashboard Persistence

The `showDetails` toggle (the per-module "Details anzeigen"/"Details ausblenden" button) now persists in `localStorage` under `ihk_progress_show_details`. Initial state reads from storage on mount via lazy `useState` initialization, and a `useEffect` writes the new value whenever it changes. Both readers and writers are wrapped in try/catch to fail silently in private-browsing or quota-exceeded scenarios.

### Test Coverage

- **`AuthModal.test.tsx`** (8 tests) — Covers character counter, "Format OK" / "noch X Zeichen fehlen" hints, paste normalization (including whitespace-only rejection), submit-disabled-until-valid behavior, and the trimmed-hash pass-through to `onLogin`.
- **`StudyCard.test.tsx`** (12 tests) — Covers the welcome screen's keyboard hints, dismissible changelog (including localStorage persistence and re-open), `aria-live` feedback region, Enter-to-check and N-to-next shortcuts, N-not-hijacked-while-typing behavior, and the stepped solution reveal (single-step and "show all" paths).
- **`ProgressDashboard.test.tsx`** (extended) — Adds four tests for `showDetails` localStorage persistence and resets `window.localStorage` in `beforeEach` blocks so tests don't bleed state across runs.

Test count moved from 212 to 236 (+24 new).

---

## Summary

This PR is a UX polish pass focused on reliability, accessibility, and keyboard handling across the trainer components.

### Key changes

**`ProgressDashboard.tsx` – safer localStorage binding**
- Replaced the manual `useState` + `useEffect` localStorage sync with `useSyncExternalStore`.
- Introduced a dedicated `SHOW_DETAILS_CHANGE_EVENT` plus a `subscribeShowDetails` listener so writes notify subscribers immediately, and the component reflects the persisted state on hydration without a setState-in-effect race.
- Removed the separate persistence effect; toggling now goes through a single `writeShowDetails`/`toggleShowDetails` path.

**`StudyCard.tsx` – keyboard handling refinements**
- Hoisted the `linuxTerminalConfig` lookup so the keydown handler and submit path share one derived value instead of recomputing the same conditions twice.
- Added an `ownsEnterKey` helper: pressing Enter while focus is on a button, link, select, textarea, or other interactive role no longer triggers the global "check answer" shortcut. This fixes accidental double-checks when the user activates a control with Enter.
- `contentEditable` elements are now also treated as text-entry targets, preventing Enter from firing the global check while typing in editable areas.
- Added `answers` to the keydown effect's dependency list so the handler always closes over fresh input state.
- Dropped the stale "Frage überspringen (N)" tooltip hint to reflect the actual shortcut surface.

**`AuthModal.tsx` – paste handling and copy**
- The paste handler now calls `e.preventDefault()` first and writes the normalized hash directly into the controlled input, so the length counter and validation only see cleaned codes.
- The "paste received" hint is now cleared via a `useEffect` timer (cleanly cancelled on unmount) instead of an unguarded `setTimeout`, and is no longer left running when the paste is rejected.
- Fixed the German singular/plural copy for the character counter ("1 Zeichen fehlt." vs "… fehlen.").

### Tests
- `ProgressDashboard.test.tsx` updated for the new async hydration path: the "starts expanded" assertion now uses `findByText`, and the toggle tests explicitly assert the post-toggle label to guard against race conditions.

### Impact
These changes make the persistence of the "Details anzeigen" toggle race-free across tabs/components, prevent Enter from mis-firing the answer check on interactive controls, and clean up paste/copy behavior in the auth modal — all without altering public component APIs.
<!-- kody-pr-summary:end -->