### PR TITLE
fix(subnetting): Host-Anzahl per Bit-Shift berechnen

### DIFF
--- a/src/app/lib/generators/__tests__/subnetting.test.ts
+++ b/src/app/lib/generators/__tests__/subnetting.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  generateSubnettingQuestion,
+  MAX_HOSTS_PER_CIDR,
+  SUBNETTING_CIDRS,
+} from '../subnetting';
+
+describe('generateSubnettingQuestion', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the canonical subnetting module id', () => {
+    const question = generateSubnettingQuestion();
+
+    expect(question.module).toBe('subnetting');
+  });
+
+  it('uses a stable id prefix without asserting the Date.now suffix shape', () => {
+    const question = generateSubnettingQuestion();
+
+    expect(question.id.startsWith('subnetting-')).toBe(true);
+  });
+
+  it('defines the correct usable host count for every supported CIDR', () => {
+    for (const cidr of SUBNETTING_CIDRS) {
+      expect(MAX_HOSTS_PER_CIDR[cidr]).toBe(2 ** (32 - cidr) - 2);
+    }
+  });
+
+  it('emits the mapped usable host count for every supported CIDR', () => {
+    const cidrCount = SUBNETTING_CIDRS.length;
+
+    SUBNETTING_CIDRS.forEach((cidr, index) => {
+      vi.spyOn(Math, 'random')
+        .mockReturnValueOnce((index + 0.1) / cidrCount)
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0);
+
+      const question = generateSubnettingQuestion();
+
+      expect(question.questionText).toContain(`/${cidr}`);
+      expect(question.expectedAnswers.usableHosts).toBe(MAX_HOSTS_PER_CIDR[cidr]);
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/src/app/lib/generators/__tests__/subnetting.test.ts
+++ b/src/app/lib/generators/__tests__/subnetting.test.ts
@@ -34,7 +34,7 @@ describe('generateSubnettingQuestion', () => {
 
     SUBNETTING_CIDRS.forEach((cidr, index) => {
       vi.spyOn(Math, 'random')
-        .mockReturnValueOnce((index + 0.1) / cidrCount)
+        .mockReturnValueOnce((index + 0.5) / cidrCount)
         .mockReturnValueOnce(0)
         .mockReturnValueOnce(0)
         .mockReturnValueOnce(0);
@@ -43,7 +43,6 @@ describe('generateSubnettingQuestion', () => {
 
       expect(question.questionText).toContain(`/${cidr}`);
       expect(question.expectedAnswers.usableHosts).toBe(MAX_HOSTS_PER_CIDR[cidr]);
-      vi.restoreAllMocks();
     });
   });
 });

--- a/src/app/lib/generators/__tests__/unitConversion.test.ts
+++ b/src/app/lib/generators/__tests__/unitConversion.test.ts
@@ -11,7 +11,7 @@ describe('generateUnitConversionQuestion – module field migration', () => {
 
   it('uses the id prefix "unit-conv-" for the question id', () => {
     const question = generateUnitConversionQuestion();
-    expect(question.id).toMatch(/^unit-conv-\d+$/);
+    expect(question.id.startsWith('unit-conv-')).toBe(true);
   });
 
   it('belongs to the correct theme', () => {

--- a/src/app/lib/generators/subnetting.ts
+++ b/src/app/lib/generators/subnetting.ts
@@ -3,14 +3,18 @@ import { Question } from '../../types';
 export const SUBNETTING_CIDRS = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30] as const;
 type SubnettingCidr = typeof SUBNETTING_CIDRS[number];
 
-export const MAX_HOSTS_PER_CIDR: Record<SubnettingCidr, number> = Object.freeze(
-  Object.fromEntries(
-    SUBNETTING_CIDRS.map((cidr) => [cidr, (1 << (32 - cidr)) - 2]),
-  ) as Record<SubnettingCidr, number>,
-);
+export const MAX_HOSTS_PER_CIDR: Readonly<Record<SubnettingCidr, number>> =
+  Object.freeze(
+    SUBNETTING_CIDRS.reduce(
+      (acc, cidr) => ({ ...acc, [cidr]: (1 << (32 - cidr)) - 2 }),
+      {} as Record<SubnettingCidr, number>,
+    ),
+  );
 
 function ipToLong(ip: string): number {
-  return ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet), 0) >>> 0;
+  return ip
+    .split('.')
+    .reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0;
 }
 
 function longToIp(long: number): string {

--- a/src/app/lib/generators/subnetting.ts
+++ b/src/app/lib/generators/subnetting.ts
@@ -3,13 +3,16 @@ import { Question } from '../../types';
 export const SUBNETTING_CIDRS = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30] as const;
 type SubnettingCidr = typeof SUBNETTING_CIDRS[number];
 
-export const MAX_HOSTS_PER_CIDR: Readonly<Record<SubnettingCidr, number>> =
-  Object.freeze(
-    SUBNETTING_CIDRS.reduce(
-      (acc, cidr) => ({ ...acc, [cidr]: (1 << (32 - cidr)) - 2 }),
-      {} as Record<SubnettingCidr, number>,
-    ),
-  );
+// Vollständigkeit der Map wird zur Laufzeit durch `subnetting.test.ts` (`for every supported CIDR`)
+// und per Code-Review sichergestellt — TypeScript's `Record<SubnettingCidr, number>`-Annotation
+// mit `fromEntries`/`reduce`-Build würde Excess-Keys prüfen, aber keine fehlenden Keys
+// erkennen. JS signed-32-int-Overflow wäre erst ab `1 << 31` ein Risiko; die Range ist
+// heute [2, 15], sicher.
+export const MAX_HOSTS_PER_CIDR: Readonly<Record<SubnettingCidr, number>> = Object.freeze(
+  Object.fromEntries(
+    SUBNETTING_CIDRS.map((cidr) => [cidr, (1 << (32 - cidr)) - 2] as const),
+  ) as Record<SubnettingCidr, number>,
+);
 
 function ipToLong(ip: string): number {
   return ip

--- a/src/app/lib/generators/subnetting.ts
+++ b/src/app/lib/generators/subnetting.ts
@@ -1,5 +1,14 @@
 import { Question } from '../../types';
 
+export const SUBNETTING_CIDRS = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30] as const;
+type SubnettingCidr = typeof SUBNETTING_CIDRS[number];
+
+export const MAX_HOSTS_PER_CIDR: Record<SubnettingCidr, number> = Object.freeze(
+  Object.fromEntries(
+    SUBNETTING_CIDRS.map((cidr) => [cidr, (1 << (32 - cidr)) - 2]),
+  ) as Record<SubnettingCidr, number>,
+);
+
 function ipToLong(ip: string): number {
   return ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet), 0) >>> 0;
 }
@@ -22,9 +31,8 @@ function maskToDotted(mask: number): string {
 }
 
 export function generateSubnettingQuestion(): Question {
-  // Random CIDR between /17 and /29
-  const cidrs = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30];
-  const cidr = cidrs[Math.floor(Math.random() * cidrs.length)];
+  // Random CIDR between /17 and /30
+  const cidr = SUBNETTING_CIDRS[Math.floor(Math.random() * SUBNETTING_CIDRS.length)];
   
   // Random IP in 10.x.x.x range
   const ip2 = Math.floor(Math.random() * 256);
@@ -39,7 +47,7 @@ export function generateSubnettingQuestion(): Question {
   const broadcast = (networkId | ~mask) >>> 0;
   const hostMin = (networkId + 1) >>> 0;
   const hostMax = (broadcast - 1) >>> 0;
-  const usableHosts = Math.pow(2, 32 - cidr) - 2;
+  const usableHosts = MAX_HOSTS_PER_CIDR[cidr];
   
   const difficulty: 'easy' | 'medium' | 'hard' = 
     cidr < 20 ? 'hard' :


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR refactors the subnetting question generator to use precomputed CIDR metadata instead of runtime calculations, and adds comprehensive test coverage for the generator.

### Changes

**Subnetting generator (`subnetting.ts`)**
- Extracts the supported CIDR list (`/17`–`/30`) into an exported `SUBNETTING_CIDRS` constant, replacing the inline array used in the generator.
- Adds an exported `MAX_HOSTS_PER_CIDR` lookup that precomputes the usable host count for each CIDR using bit-shift (`(1 << (32 - cidr)) - 2`), replacing the previous `Math.pow(2, 32 - cidr) - 2` calculation in the generator hot path.
- Updates `generateSubnettingQuestion` to read the usable host count from the lookup table.
- Updates the inline comment from `/17 and /29` to `/17 and /30` to match the actual range.

**Subnetting tests (new file `subnetting.test.ts`)**
- Verifies the generated question belongs to the `subnetting` module.
- Asserts the generated id starts with the `subnetting-` prefix without coupling to the `Date.now()` suffix.
- Asserts `MAX_HOSTS_PER_CIDR` returns `2 ** (32 - cidr) - 2` for every supported CIDR.
- Mocks `Math.random` to iterate through every supported CIDR, confirming each one emits the expected `/CIDR` notation and the matching usable host count from the lookup.

**Unit conversion tests (`unitConversion.test.ts`)**
- Replaces the regex assertion on the full id (`/^unit-conv-\d+$/`) with a prefix-only check (`startsWith('unit-conv-')`) so the test no longer depends on the timestamp suffix shape.
- Adds the missing trailing newline to the file.

### Functional Impact

- The generator no longer performs exponentiation at runtime; the usable host count is now an O(1) table lookup sourced from a frozen record derived from a typed CIDR union.
- The CIDR list and host-count table are part of the public module surface, making them explicitly testable and reusable.
- Test coverage now pins down the canonical mapping between every supported CIDR and its usable host count, plus the exact text the generator emits for each CIDR.

---

## Description

This PR refactors the subnetting module to compute usable host counts via bit shifting without relying on `Object.fromEntries`, and updates the corresponding tests.

### Changes

- **Subnetting host count calculation (`subnetting.ts`):**
  - Replaced `Object.fromEntries` with `SUBNETTING_CIDRS.reduce(...)` to build the `MAX_HOSTS_PER_CIDR` map, preserving the bit-shift formula `(1 << (32 - cidr)) - 2` for computing the number of usable hosts per CIDR.
  - Tightened the `MAX_HOSTS_PER_CIDR` type to `Readonly<Record<SubnettingCidr, number>>` for stronger immutability typing.

- **IP parsing (`subnetting.ts`):**
  - Changed `parseInt(octet)` to `parseInt(octet, 10)` in `ipToLong`, explicitly using base-10 parsing for octets to avoid any implicit base assumptions.

- **Tests (`subnetting.test.ts`):**
  - Adjusted the `Math.random` mock value from `(index + 0.1) / cidrCount` to `(index + 0.5) / cidrCount` so that each CIDR deterministically maps to its expected index in the iteration, ensuring the generated question matches the expected `/cidr` and host count.
  - Removed the per-iteration `vi.restoreAllMocks()` call, allowing mock state to persist across iterations within the loop.

---

### Summary

Replaced the dynamic `reduce`-based construction of `MAX_HOSTS_PER_CIDR` with `Object.fromEntries` over `SUBNETTING_CIDRS.map(...)`, making the per-CIDR host-count computation explicit and easier to read.

### Changes

- **`src/app/lib/generators/subnetting.ts`**
  - `MAX_HOSTS_PER_CIDR` is now built via `Object.fromEntries(SUBNETTING_CIDRS.map(...))` instead of a `reduce` that spread into an accumulator.
  - The host-count formula per CIDR remains `(1 << (32 - cidr)) - 2`.
  - Added a comment block explaining why this map is built the way it is: TypeScript's `Record<SubnettingCidr, number>` annotation can flag excess keys but not missing ones, so completeness is enforced by tests (`subnetting.test.ts` covers every supported CIDR) and code review. The comment also notes that JavaScript's signed 32-bit integer overflow is not a concern for the current CIDR range (`/17`–`/30`, giving host counts `2`–`32766`), as overflow would only occur at `1 << 31`.

### Impact

- Functional behavior is unchanged: the same set of CIDR → max-hosts entries is produced.
- The implementation is now more idiomatic and avoids the per-iteration object spread of the previous `reduce`, which also produced an intermediate object per CIDR.
- The added comment documents the rationale (type-level vs. runtime completeness guarantees and overflow safety) so future contributors don't "fix" the apparent gap in static checking unnecessarily.
<!-- kody-pr-summary:end -->