### PR TITLE
chore(changelog): aktuelle Neuerungen im Was-ist-neu-Bereich

### DIFF
--- a/src/app/components/__tests__/StudyCard.test.tsx
+++ b/src/app/components/__tests__/StudyCard.test.tsx
@@ -152,7 +152,7 @@ describe('StudyCard – welcome screen (no question)', () => {
     );
     await userEvent.click(screen.getByText('Was ist neu?'));
     // Should now reveal the most recent changelog entry.
-    expect(screen.getByText(/Hexa \/ Binaer Aufgaben/)).toBeInTheDocument();
+    expect(screen.getByText(/Confetti, UX, Upstash/)).toBeInTheDocument();
   });
 });
 

--- a/src/app/lib/changelog.ts
+++ b/src/app/lib/changelog.ts
@@ -6,11 +6,15 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
-
+  {
+    date: '28/06/2026',
+    summary: 'Confetti, UX, Upstash, Security, Subnetting',
+    highlight: true,
+    tag: 'Aktuell',
+  },
   { 
     date: '08/04/2026',
     summary: 'Hexa / Binaer Aufgaben, Code fixes', 
-    highlight: true,
     tag: 'Neu',
   },
   {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Update the "Was ist neu?" (What's new?) section on the welcome screen by adding a new current highlight entry and demoting the April 2026 entry.

## Changes

### Changelog data (`src/app/lib/changelog.ts`)
- **Added** a new top entry dated 28/06/2026 with the summary "Confetti, UX, Upstash, Security, Subnetting", flagged as `highlight: true` with tag `'Aktuell'`.
- **Modified** the existing April 2026 entry (08/04/2026, "Hexa / Binaer Aufgaben, Code fixes"): removed its `highlight: true` flag and changed its tag from `'Neu'` to keep it listed as a regular past entry without the highlight marker.

### Tests (`src/app/components/__tests__/StudyCard.test.tsx`)
- **Updated** the `StudyCard – welcome screen` test expectation: the assertion that checks the revealed "most recent changelog entry" was changed from matching `/Hexa \/ Binaer Aufgaben/` to matching `/Confetti, UX, Upstash/`, aligning the test with the new latest entry.

## Functional Impact
- Users opening the welcome screen now see the June 28, 2026 update (Confetti, UX, Upstash, Security, Subnetting) as the highlighted current news entry.
- The previous April 2026 update remains in the changelog list but is no longer marked as the current highlight.
- The welcome-screen test now verifies that the newest entry is correctly surfaced.
<!-- kody-pr-summary:end -->