### PR TITLE
feat(subnetting): SVG-Visualizer für Subnetting-Aufgaben

### DIFF
--- a/src/app/components/StudyCard.tsx
+++ b/src/app/components/StudyCard.tsx
@@ -484,8 +484,9 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
         </p>
       </div>
 
-      {/* Module-specific visuals. Currently: subnetting visualizer. */}
-      {question.module === 'subnetting' && (
+      {/* Module-specific visuals. The subnetting visualizer contains answer
+          values, so it only appears after submitting or opening the solution. */}
+      {question.module === 'subnetting' && (checked || showSolution) && (
         <div className="px-6 pb-2">
           <SubnettingVisualizer question={question} />
         </div>

--- a/src/app/components/StudyCard.tsx
+++ b/src/app/components/StudyCard.tsx
@@ -16,6 +16,7 @@ import { Question } from '../types';
 import { fireFirstCorrectConfetti } from '../lib/celebrations';
 import { CHANGELOG_ENTRIES } from '../lib/changelog';
 import LinuxTerminal from './LinuxTerminal';
+import SubnettingVisualizer from './SubnettingVisualizer';
 
 interface StudyCardProps {
   question: Question | null;
@@ -482,6 +483,13 @@ export default function StudyCard({ question, onCheckAnswer, onNextQuestion }: S
           {question.questionText}
         </p>
       </div>
+
+      {/* Module-specific visuals. Currently: subnetting visualizer. */}
+      {question.module === 'subnetting' && (
+        <div className="px-6 pb-2">
+          <SubnettingVisualizer question={question} />
+        </div>
+      )}
 
       {/* Answer Inputs */}
       <div className="px-6 pb-4 space-y-4">

--- a/src/app/components/SubnettingVisualizer.tsx
+++ b/src/app/components/SubnettingVisualizer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { Network, Eye } from 'lucide-react';
 import type { Question } from '../types';
 
@@ -107,6 +107,7 @@ interface SubnettingVisualizerProps {
  * hostMax, subnetMask, usableHosts all present).
  */
 export default function SubnettingVisualizer({ question }: SubnettingVisualizerProps) {
+  const prefersReducedMotion = useReducedMotion();
   const parsed = useMemo(() => {
     const fromText = parseIpAndCidr(question.questionText);
     const maskStr = String(question.expectedAnswers.subnetMask ?? '');
@@ -126,7 +127,9 @@ export default function SubnettingVisualizer({ question }: SubnettingVisualizerP
 
   return (
     <motion.section
-      initial={{ opacity: 0, y: 6 }}
+      // Respect prefers-reduced-motion: users with vestibular sensitivity
+      // see an instant mount instead of a 6px slide.
+      initial={prefersReducedMotion ? false : { opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25, ease: 'easeOut' }}
       aria-label="Subnetting Visualisierung"
@@ -169,7 +172,7 @@ export default function SubnettingVisualizer({ question }: SubnettingVisualizerP
       {/* ----------------------------------------------------------------- */}
       {parsed.cidr !== null && (
         <div className="px-5 pt-4 pb-3 border-b border-slate-800/60">
-          <SectionLabel icon={<Eye className="w-3 h-3" />}>
+          <SectionLabel icon={<Eye className="w-3 h-3" aria-hidden="true" />}>
             32-Bit-Aufteilung
           </SectionLabel>
           <BitBar cidr={parsed.cidr} />
@@ -180,7 +183,7 @@ export default function SubnettingVisualizer({ question }: SubnettingVisualizerP
       {/* Address range bar                                                  */}
       {/* ----------------------------------------------------------------- */}
       <div className="px-5 pt-4 pb-4 border-b border-slate-800/60">
-        <SectionLabel icon={<Eye className="w-3 h-3" />}>
+        <SectionLabel icon={<Eye className="w-3 h-3" aria-hidden="true" />}>
           Adressbereich im Subnetz
         </SectionLabel>
         <RangeBar

--- a/src/app/components/SubnettingVisualizer.tsx
+++ b/src/app/components/SubnettingVisualizer.tsx
@@ -39,9 +39,8 @@ export function parseIpAndCidr(text: string): ParsedSubnetInput | null {
   if (!match) return null;
   const octets = [match[1], match[2], match[3], match[4]].map((s) => {
     const n = Number(s);
-    return Number.isFinite(n) ? Math.trunc(n) : NaN;
+    return Number.isFinite(n) ? n : NaN;
   });
-  if (octets.length !== 4) return null;
   if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
   const cidr = Number(match[5]);
   if (!Number.isInteger(cidr) || cidr < 0 || cidr > 32) return null;
@@ -123,7 +122,7 @@ export default function SubnettingVisualizer({ question }: SubnettingVisualizerP
   const hostMax = String(question.expectedAnswers.hostMax ?? '');
   const usableHosts = Number(question.expectedAnswers.usableHosts ?? 0);
   const totalAddresses =
-    parsed.cidr === null ? null : 1 << (32 - parsed.cidr);
+    parsed.cidr === null ? null : 2 ** (32 - parsed.cidr);
 
   return (
     <motion.section
@@ -498,7 +497,7 @@ function RangeBar({
       {totalAddresses !== null && (
         <text
           x={320}
-          y={5}
+          y={12}
           fontSize="9"
           textAnchor="end"
           fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"

--- a/src/app/components/SubnettingVisualizer.tsx
+++ b/src/app/components/SubnettingVisualizer.tsx
@@ -1,0 +1,512 @@
+'use client';
+
+import { useMemo } from 'react';
+import { motion } from 'framer-motion';
+import { Network, Eye } from 'lucide-react';
+import type { Question } from '../types';
+
+// ===========================================================================
+// Pure helpers (exported for unit testing)
+// ===========================================================================
+
+/**
+ * Match an IPv4 address with a `/CIDR` suffix.
+ * Tolerates whitespace around the slash and accepts 1–3 digit octets.
+ *
+ * The pattern intentionally anchors on a digit so it doesn't catch IPs that
+ * appear inside larger numbers or sentence fragments.
+ */
+const IPV4_WITH_CIDR =
+  /(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\s*\/\s*(\d{1,2})(?!\d)/;
+
+export interface ParsedSubnetInput {
+  ip: string;
+  cidr: number;
+}
+
+/**
+ * Parse the first IPv4/CIDR token from a free-form text (the subnetting
+ * generator embeds it in `questionText` as `Gegeben: IP-Adresse 10.5.3.4/24`).
+ *
+ * Returns null when:
+ *   • no IPv4/CIDR token is found
+ *   • any octet is outside 0–255
+ *   • the CIDR is outside 0–32
+ */
+export function parseIpAndCidr(text: string): ParsedSubnetInput | null {
+  if (typeof text !== 'string' || text.length === 0) return null;
+  const match = text.match(IPV4_WITH_CIDR);
+  if (!match) return null;
+  const octets = [match[1], match[2], match[3], match[4]].map((s) => {
+    const n = Number(s);
+    return Number.isFinite(n) ? Math.trunc(n) : NaN;
+  });
+  if (octets.length !== 4) return null;
+  if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+  const cidr = Number(match[5]);
+  if (!Number.isInteger(cidr) || cidr < 0 || cidr > 32) return null;
+  return { ip: `${octets[0]}.${octets[1]}.${octets[2]}.${octets[3]}`, cidr };
+}
+
+function popcountByte(n: number): number {
+  let count = 0;
+  let value = n;
+  while (value > 0) {
+    count += value & 1;
+    value >>>= 1;
+  }
+  return count;
+}
+
+/**
+ * Derive the CIDR prefix length from a dotted-decimal subnet mask.
+ *
+ * The subnetting generator always emits a valid contiguous mask (`255.0.0.0`,
+ * `255.255.252.0`, etc.), so a plain popcount over the four octets is enough
+ * for the visualizer. We intentionally don't validate "contiguity" — a mask
+ * the generator can't produce should be surfaced as an unexpected value rather
+ * than silently coerced.
+ *
+ * Returns null when `mask` is not a parseable IPv4 dotted-decimal string.
+ */
+export function countCidrFromMask(mask: string): number | null {
+  if (typeof mask !== 'string' || mask.length === 0) return null;
+  const parts = mask.split('.');
+  if (parts.length !== 4) return null;
+  let bits = 0;
+  for (const raw of parts) {
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+    bits += popcountByte(n);
+  }
+  // Each octet is 0–255 (max 8 set bits), so the popcount sum is always
+  // ≤ 32 by construction. We trust the per-octet range check above; any
+  // non-contiguous mask the generator can't produce would have surfaced
+  // as an unexpected value rather than silently being coerced.
+  return bits;
+}
+
+// ===========================================================================
+// Component
+// ===========================================================================
+
+interface SubnettingVisualizerProps {
+  question: Question;
+}
+
+/**
+ * SVG-based visual breakdown of a subnetting question.
+ *
+ * Layers three things:
+ *   1. 32-bit split bar (network bits vs host bits, octet boundaries).
+ *   2. Address-range bar (Network → Host min → Host max → Broadcast).
+ *   3. Detail grid with the exact expected values.
+ *
+ * Rendered only when the StudyCard gates on `question.module === 'subnetting'`.
+ * The component itself is pure and never renders for other module ids — it
+ * assumes a well-formed subnetting Question (networkId, broadcast, hostMin,
+ * hostMax, subnetMask, usableHosts all present).
+ */
+export default function SubnettingVisualizer({ question }: SubnettingVisualizerProps) {
+  const parsed = useMemo(() => {
+    const fromText = parseIpAndCidr(question.questionText);
+    const maskStr = String(question.expectedAnswers.subnetMask ?? '');
+    const fromMask = countCidrFromMask(maskStr);
+    const cidr = fromText?.cidr ?? fromMask ?? null;
+    const ip = fromText?.ip ?? null;
+    return { ip, cidr, maskStr };
+  }, [question.questionText, question.expectedAnswers.subnetMask]);
+
+  const networkId = String(question.expectedAnswers.networkId ?? '');
+  const broadcast = String(question.expectedAnswers.broadcast ?? '');
+  const hostMin = String(question.expectedAnswers.hostMin ?? '');
+  const hostMax = String(question.expectedAnswers.hostMax ?? '');
+  const usableHosts = Number(question.expectedAnswers.usableHosts ?? 0);
+  const totalAddresses =
+    parsed.cidr === null ? null : 1 << (32 - parsed.cidr);
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+      aria-label="Subnetting Visualisierung"
+      data-testid="subnetting-visualizer"
+      className="rounded-xl border border-slate-800 bg-slate-950/50 overflow-hidden"
+    >
+      {/* ----------------------------------------------------------------- */}
+      {/* Header                                                              */}
+      {/* ----------------------------------------------------------------- */}
+      <header className="flex flex-wrap items-baseline gap-3 px-5 py-3 border-b border-slate-800 bg-slate-900/40">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-emerald-500/10 text-emerald-400">
+            <Network className="w-3.5 h-3.5" aria-hidden="true" />
+          </span>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-emerald-400">
+            Visuelle Aufschlüsselung
+          </h3>
+        </div>
+        <div className="ml-auto flex flex-wrap items-baseline gap-2 text-sm font-mono">
+          {parsed.ip && (
+            <span className="text-slate-100" data-testid="viz-given-ip">
+              {parsed.ip}
+            </span>
+          )}
+          {parsed.cidr !== null && (
+            <span className="text-emerald-400 font-semibold" data-testid="viz-cidr">
+              /{parsed.cidr}
+            </span>
+          )}
+          {parsed.maskStr && (
+            <span className="text-slate-500 text-xs">
+              Maske: <span className="text-slate-300">{parsed.maskStr}</span>
+            </span>
+          )}
+        </div>
+      </header>
+
+      {/* ----------------------------------------------------------------- */}
+      {/* 32-bit split bar                                                   */}
+      {/* ----------------------------------------------------------------- */}
+      {parsed.cidr !== null && (
+        <div className="px-5 pt-4 pb-3 border-b border-slate-800/60">
+          <SectionLabel icon={<Eye className="w-3 h-3" />}>
+            32-Bit-Aufteilung
+          </SectionLabel>
+          <BitBar cidr={parsed.cidr} />
+        </div>
+      )}
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Address range bar                                                  */}
+      {/* ----------------------------------------------------------------- */}
+      <div className="px-5 pt-4 pb-4 border-b border-slate-800/60">
+        <SectionLabel icon={<Eye className="w-3 h-3" />}>
+          Adressbereich im Subnetz
+        </SectionLabel>
+        <RangeBar
+          networkId={networkId}
+          broadcast={broadcast}
+          hostMin={hostMin}
+          hostMax={hostMax}
+          totalAddresses={totalAddresses}
+          usableHosts={usableHosts}
+        />
+      </div>
+
+      {/* ----------------------------------------------------------------- */}
+      {/* Detail grid                                                        */}
+      {/* ----------------------------------------------------------------- */}
+      <dl
+        className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-3 px-5 py-4 text-sm"
+        aria-label="Erwartete Subnetz-Werte"
+      >
+        <DetailRow label="Network ID" value={networkId} tone="emerald" testId="viz-network-id" />
+        <DetailRow label="Broadcast" value={broadcast} tone="rose" testId="viz-broadcast" />
+        <DetailRow label="Subnetzmaske" value={parsed.maskStr} tone="slate" testId="viz-mask" />
+        <DetailRow label="Erster Host" value={hostMin} tone="amber" testId="viz-host-min" />
+        <DetailRow label="Letzter Host" value={hostMax} tone="amber" testId="viz-host-max" />
+        <DetailRow
+          label="Nutzbare Hosts"
+          value={usableHosts.toLocaleString('de-DE')}
+          tone="emerald"
+          testId="viz-usable-hosts"
+        />
+      </dl>
+    </motion.section>
+  );
+}
+
+// ===========================================================================
+// Subcomponents
+// ===========================================================================
+
+function SectionLabel({
+  children,
+  icon,
+}: {
+  children: React.ReactNode;
+  icon?: React.ReactNode;
+}) {
+  return (
+    <p className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500 mb-2">
+      {icon}
+      <span>{children}</span>
+    </p>
+  );
+}
+
+type Tone = 'emerald' | 'rose' | 'amber' | 'slate';
+
+const TONE_TEXT: Record<Tone, string> = {
+  emerald: 'text-emerald-400',
+  rose: 'text-rose-400',
+  amber: 'text-amber-300',
+  slate: 'text-slate-400',
+};
+
+const TONE_VALUE: Record<Tone, string> = {
+  emerald: 'text-emerald-200',
+  rose: 'text-rose-200',
+  amber: 'text-amber-200',
+  slate: 'text-slate-200',
+};
+
+function DetailRow({
+  label,
+  value,
+  tone,
+  testId,
+}: {
+  label: string;
+  value: string;
+  tone: Tone;
+  testId?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className={`text-[10px] uppercase tracking-wider ${TONE_TEXT[tone]}`}>
+        {label}
+      </dt>
+      <dd
+        className={`font-mono text-sm break-all ${TONE_VALUE[tone]}`}
+        data-testid={testId}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+/**
+ * 32-cell bit bar showing the network/host split, with octet dividers
+ * and a vertical "CIDR divider" line at the bit boundary.
+ *
+ * Geometry (in user units):
+ *   viewBox: 0 0 320 60
+ *   cell width: 10, gap: 0 (32 cells × 10 = 320 wide)
+ *   cells live at y=24..46 (height 22)
+ */
+function BitBar({ cidr }: { cidr: number }) {
+  const networkBits = Math.max(0, Math.min(32, cidr));
+  const hostBits = 32 - networkBits;
+  const cells = Array.from({ length: 32 }, (_, i) => i);
+  return (
+    <svg
+      viewBox="0 0 320 60"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label={`32-Bit-Aufteilung: ${networkBits} Netzwerk-Bits, ${hostBits} Host-Bits`}
+      className="w-full h-auto"
+    >
+      {/* Octet labels */}
+      {['1–8', '9–16', '17–24', '25–32'].map((label, i) => {
+        const x = i * 80 + 40; // center of each octet group (80 units wide)
+        return (
+          <text
+            key={label}
+            x={x}
+            y={12}
+            textAnchor="middle"
+            fontSize="9"
+            fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+            fill="#64748b"
+          >
+            {label}
+          </text>
+        );
+      })}
+
+      {/* Octet divider lines (between octets — subtle) */}
+      {[1, 2, 3].map((i) => (
+        <line
+          key={`oct-${i}`}
+          x1={i * 80}
+          y1={20}
+          x2={i * 80}
+          y2={50}
+          stroke="#1e293b"
+          strokeWidth={1}
+        />
+      ))}
+
+      {/* Bit cells */}
+      {cells.map((i) => {
+        const isNetwork = i < networkBits;
+        return (
+          <rect
+            key={i}
+            x={i * 10 + 0.5}
+            y={24}
+            width={9}
+            height={22}
+            rx={1}
+            fill={isNetwork ? '#10b981' : '#475569'}
+            fillOpacity={isNetwork ? 0.85 : 0.45}
+            stroke="#0f172a"
+            strokeWidth={0.5}
+          />
+        );
+      })}
+
+      {/* CIDR divider — vertical dashed line at the network/host boundary */}
+      {networkBits > 0 && networkBits < 32 && (
+        <line
+          x1={networkBits * 10}
+          y1={18}
+          x2={networkBits * 10}
+          y2={52}
+          stroke="#fb7185"
+          strokeWidth={1.5}
+          strokeDasharray="3 2"
+        />
+      )}
+
+      {/* Legend */}
+      <text
+        x={0}
+        y={58}
+        fontSize="9"
+        fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+        fill="#10b981"
+      >
+        Netzwerk
+      </text>
+      <text
+        x={320}
+        y={58}
+        fontSize="9"
+        textAnchor="end"
+        fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+        fill="#94a3b8"
+      >
+        Host
+      </text>
+    </svg>
+  );
+}
+
+/**
+ * Horizontal bar showing the relative position of Network ID, the host range,
+ * and the Broadcast address within the subnet. N is always at the left edge,
+ * B at the right edge, and the host range covers everything in between.
+ */
+function RangeBar({
+  networkId,
+  broadcast,
+  hostMin,
+  hostMax,
+  totalAddresses,
+  usableHosts,
+}: {
+  networkId: string;
+  broadcast: string;
+  hostMin: string;
+  hostMax: string;
+  totalAddresses: number | null;
+  usableHosts: number;
+}) {
+  return (
+    <svg
+      viewBox="0 0 320 70"
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label={`Adressbereich: ${networkId} (Network) bis ${broadcast} (Broadcast), nutzbare Hosts ${hostMin} bis ${hostMax}`}
+      className="w-full h-auto"
+    >
+      {/* Background bar */}
+      <rect x={0} y={28} width={320} height={10} rx={2} fill="#1e293b" />
+
+      {/* Host-range highlight (everything except N and B endpoints) */}
+      <rect
+        x={6}
+        y={30}
+        width={308}
+        height={6}
+        rx={1}
+        fill="#10b981"
+        fillOpacity={0.45}
+      />
+
+      {/* Network ID marker (left edge) */}
+      <g>
+        <line x1={0} y1={18} x2={0} y2={48} stroke="#10b981" strokeWidth={2} />
+        <circle cx={0} cy={33} r={3} fill="#10b981" />
+        <text
+          x={0}
+          y={14}
+          fontSize="10"
+          textAnchor="middle"
+          fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+          fill="#10b981"
+          fontWeight={700}
+        >
+          N
+        </text>
+      </g>
+
+      {/* Broadcast marker (right edge) */}
+      <g>
+        <line x1={320} y1={18} x2={320} y2={48} stroke="#fb7185" strokeWidth={2} />
+        <circle cx={320} cy={33} r={3} fill="#fb7185" />
+        <text
+          x={320}
+          y={14}
+          fontSize="10"
+          textAnchor="middle"
+          fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+          fill="#fb7185"
+          fontWeight={700}
+        >
+          B
+        </text>
+      </g>
+
+      {/* IP labels under the bar */}
+      <text
+        x={0}
+        y={60}
+        fontSize="9"
+        textAnchor="middle"
+        fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+        fill="#cbd5e1"
+      >
+        {networkId}
+      </text>
+      <text
+        x={320}
+        y={60}
+        fontSize="9"
+        textAnchor="middle"
+        fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+        fill="#cbd5e1"
+      >
+        {broadcast}
+      </text>
+      <text
+        x={160}
+        y={60}
+        fontSize="9"
+        textAnchor="middle"
+        fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+        fill="#fbbf24"
+      >
+        {hostMin} … {hostMax}
+      </text>
+
+      {/* Count chip top-right */}
+      {totalAddresses !== null && (
+        <text
+          x={320}
+          y={5}
+          fontSize="9"
+          textAnchor="end"
+          fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+          fill="#64748b"
+        >
+          {totalAddresses.toLocaleString('de-DE')} Adressen · {usableHosts.toLocaleString('de-DE')} nutzbar
+        </text>
+      )}
+    </svg>
+  );
+}

--- a/src/app/components/__tests__/StudyCard.test.tsx
+++ b/src/app/components/__tests__/StudyCard.test.tsx
@@ -35,6 +35,9 @@ vi.mock('framer-motion', () => ({
     ),
   },
   AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  // SubnettingVisualizer (rendered inside StudyCard) uses this to skip the
+  // entrance animation when the user has prefers-reduced-motion enabled.
+  useReducedMotion: () => false,
 }));
 
 // Mock lucide-react — render tiny stand-ins.
@@ -472,6 +475,44 @@ describe('StudyCard – subnetting visualizer gating', () => {
     expect(within(visualizer).getByTestId('viz-cidr')).toHaveTextContent('/24');
     expect(within(visualizer).getByTestId('viz-network-id')).toHaveTextContent('10.5.3.0');
     expect(within(visualizer).getByTestId('viz-broadcast')).toHaveTextContent('10.5.3.255');
+    expect(within(visualizer).getByTestId('viz-usable-hosts')).toHaveTextContent('254');
+  });
+
+  // Regression guard: the gate is `(checked || showSolution)`. The showSolution
+  // branch is covered above; this one locks in the post-submit (`checked`)
+  // branch so a future refactor that drops `checked` from the condition fails
+  // CI instead of silently leaking answers before the user submits.
+  it('renders the subnetting visualizer after submitting an answer', async () => {
+    const user = userEvent.setup();
+    render(
+      <StudyCard
+        question={makeSubnettingQuestion()}
+        onCheckAnswer={vi.fn().mockReturnValue(true)}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+
+    // The subnetting question has 6 expectedAnswer fields (no answerInputs).
+    // Fill every one so the "Antwort prüfen" button enables.
+    const networkIdInput = screen.getByPlaceholderText(/networkId eingeben/i);
+    const broadcastInput = screen.getByPlaceholderText(/broadcast eingeben/i);
+    const hostMinInput = screen.getByPlaceholderText(/hostMin eingeben/i);
+    const hostMaxInput = screen.getByPlaceholderText(/hostMax eingeben/i);
+    const subnetMaskInput = screen.getByPlaceholderText(/subnetMask eingeben/i);
+    const usableHostsInput = screen.getByPlaceholderText(/usableHosts eingeben/i);
+
+    await user.type(networkIdInput, '10.5.3.0');
+    await user.type(broadcastInput, '10.5.3.255');
+    await user.type(hostMinInput, '10.5.3.1');
+    await user.type(hostMaxInput, '10.5.3.254');
+    await user.type(subnetMaskInput, '255.255.255.0');
+    await user.type(usableHostsInput, '254');
+
+    await user.click(screen.getByRole('button', { name: /Antwort prüfen/i }));
+
+    const visualizer = screen.getByTestId('subnetting-visualizer');
+    expect(within(visualizer).getByTestId('viz-given-ip')).toHaveTextContent('10.5.3.4');
+    expect(within(visualizer).getByTestId('viz-cidr')).toHaveTextContent('/24');
     expect(within(visualizer).getByTestId('viz-usable-hosts')).toHaveTextContent('254');
   });
 

--- a/src/app/components/__tests__/StudyCard.test.tsx
+++ b/src/app/components/__tests__/StudyCard.test.tsx
@@ -28,6 +28,11 @@ vi.mock('framer-motion', () => ({
         {children}
       </p>
     ),
+    section: ({ children, className, ...rest }: HTMLAttributes<HTMLElement>) => (
+      <section className={className} {...rest}>
+        {children}
+      </section>
+    ),
   },
   AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -41,6 +46,9 @@ vi.mock('lucide-react', () => ({
   RotateCcw: () => <svg data-testid="icon-rotatecc" />,
   Sparkles: () => <svg data-testid="icon-sparkles" />,
   Keyboard: () => <svg data-testid="icon-keyboard" />,
+  // SubnettingVisualizer also uses these icons when its module renders.
+  Network: () => <svg data-testid="icon-network" />,
+  Eye: () => <svg data-testid="icon-eye" />,
 }));
 
 // Mock the Linux terminal — we don't want to exercise its full keyboard
@@ -408,5 +416,69 @@ describe('StudyCard – stepped solution reveal', () => {
     const answersPanel = labelEl.parentElement!.parentElement!;
     expect(within(answersPanel).getByText('1024')).toBeInTheDocument();
     expect(within(answersPanel).getByText('768')).toBeInTheDocument();
+  });
+});
+
+describe('StudyCard – subnetting visualizer gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  function makeSubnettingQuestion(): Question {
+    return {
+      id: 'sub-test-1',
+      theme: 'Netzwerkarchitektur & Overhead',
+      module: 'subnetting',
+      questionText: 'Gegeben: IP-Adresse 10.5.3.4/24\nBerechne: Network ID, Broadcast, …',
+      expectedAnswers: {
+        networkId: '10.5.3.0',
+        broadcast: '10.5.3.255',
+        hostMin: '10.5.3.1',
+        hostMax: '10.5.3.254',
+        subnetMask: '255.255.255.0',
+        usableHosts: 254,
+      },
+      solutionSteps: ['Schritt 1: …'],
+      difficulty: 'easy',
+    };
+  }
+
+  it('renders the subnetting visualizer for subnetting questions', () => {
+    render(
+      <StudyCard
+        question={makeSubnettingQuestion()}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    expect(screen.getByTestId('subnetting-visualizer')).toBeInTheDocument();
+  });
+
+  it('renders the parsed IP and CIDR header inside the visualizer', () => {
+    render(
+      <StudyCard
+        question={makeSubnettingQuestion()}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    const visualizer = screen.getByTestId('subnetting-visualizer');
+    expect(within(visualizer).getByTestId('viz-given-ip')).toHaveTextContent('10.5.3.4');
+    expect(within(visualizer).getByTestId('viz-cidr')).toHaveTextContent('/24');
+    expect(within(visualizer).getByTestId('viz-network-id')).toHaveTextContent('10.5.3.0');
+    expect(within(visualizer).getByTestId('viz-broadcast')).toHaveTextContent('10.5.3.255');
+    expect(within(visualizer).getByTestId('viz-usable-hosts')).toHaveTextContent('254');
+  });
+
+  it('does NOT render the subnetting visualizer for non-subnetting questions', () => {
+    render(
+      <StudyCard
+        question={makeQuestion()}
+        onCheckAnswer={noCheckAnswer}
+        onNextQuestion={noNextQuestion}
+      />,
+    );
+    expect(screen.queryByTestId('subnetting-visualizer')).toBeNull();
   });
 });

--- a/src/app/components/__tests__/StudyCard.test.tsx
+++ b/src/app/components/__tests__/StudyCard.test.tsx
@@ -444,7 +444,7 @@ describe('StudyCard – subnetting visualizer gating', () => {
     };
   }
 
-  it('renders the subnetting visualizer for subnetting questions', () => {
+  it('does not reveal the subnetting visualizer before submit or solution reveal', () => {
     render(
       <StudyCard
         question={makeSubnettingQuestion()}
@@ -452,10 +452,11 @@ describe('StudyCard – subnetting visualizer gating', () => {
         onNextQuestion={noNextQuestion}
       />,
     );
-    expect(screen.getByTestId('subnetting-visualizer')).toBeInTheDocument();
+    expect(screen.queryByTestId('subnetting-visualizer')).toBeNull();
   });
 
-  it('renders the parsed IP and CIDR header inside the visualizer', () => {
+  it('renders the parsed IP, CIDR, and expected values after opening the solution', async () => {
+    const user = userEvent.setup();
     render(
       <StudyCard
         question={makeSubnettingQuestion()}
@@ -463,6 +464,9 @@ describe('StudyCard – subnetting visualizer gating', () => {
         onNextQuestion={noNextQuestion}
       />,
     );
+
+    await user.click(screen.getByRole('button', { name: /Lösung anzeigen/i }));
+
     const visualizer = screen.getByTestId('subnetting-visualizer');
     expect(within(visualizer).getByTestId('viz-given-ip')).toHaveTextContent('10.5.3.4');
     expect(within(visualizer).getByTestId('viz-cidr')).toHaveTextContent('/24');

--- a/src/app/components/__tests__/SubnettingVisualizer.test.tsx
+++ b/src/app/components/__tests__/SubnettingVisualizer.test.tsx
@@ -1,0 +1,279 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+
+import SubnettingVisualizer, {
+  parseIpAndCidr,
+  countCidrFromMask,
+} from '../SubnettingVisualizer';
+import type { Question } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Framer-motion: pass through so AnimatePresence / motion.* don't fight jsdom.
+// ---------------------------------------------------------------------------
+vi.mock('framer-motion', () => ({
+  motion: {
+    section: ({
+      children,
+      className,
+      ...rest
+    }: {
+      children?: ReactNode;
+      className?: string;
+    } & React.HTMLAttributes<HTMLElement>) => (
+      <section className={className} {...rest}>
+        {children}
+      </section>
+    ),
+    div: ({
+      children,
+      className,
+      ...rest
+    }: {
+      children?: ReactNode;
+      className?: string;
+    } & React.HTMLAttributes<HTMLDivElement>) => (
+      <div className={className} {...rest}>
+        {children}
+      </div>
+    ),
+  },
+  AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+// ---------------------------------------------------------------------------
+// Lucide-react: tiny stand-ins.
+// ---------------------------------------------------------------------------
+vi.mock('lucide-react', () => ({
+  Network: () => <svg data-testid="icon-network" />,
+  Eye: () => <svg data-testid="icon-eye" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeSubnettingQuestion(overrides: Partial<Question> = {}): Question {
+  return {
+    id: 'subnetting-viz-1',
+    theme: 'Netzwerkarchitektur & Overhead',
+    module: 'subnetting',
+    questionText: 'Gegeben: IP-Adresse 10.5.3.4/24\nBerechne: Network ID, Broadcast, ...',
+    expectedAnswers: {
+      networkId: '10.5.3.0',
+      broadcast: '10.5.3.255',
+      hostMin: '10.5.3.1',
+      hostMax: '10.5.3.254',
+      subnetMask: '255.255.255.0',
+      usableHosts: 254,
+    },
+    solutionSteps: ['Schritt 1: ...'],
+    difficulty: 'easy',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ===========================================================================
+// Pure helpers
+// ===========================================================================
+
+describe('parseIpAndCidr', () => {
+  it('parses an IPv4/CIDR pair embedded in the question template', () => {
+    expect(parseIpAndCidr('Gegeben: IP-Adresse 10.5.3.4/24\nBerechne: ...')).toEqual({
+      ip: '10.5.3.4',
+      cidr: 24,
+    });
+  });
+
+  it('tolerates whitespace around the slash', () => {
+    expect(parseIpAndCidr('IP 10.0.0.1 / 8 irgendwo')).toEqual({
+      ip: '10.0.0.1',
+      cidr: 8,
+    });
+  });
+
+  it('handles /17 (smallest supported) and /32', () => {
+    expect(parseIpAndCidr('10.0.0.0/17')?.cidr).toBe(17);
+    expect(parseIpAndCidr('10.0.0.0/32')?.cidr).toBe(32);
+  });
+
+  it('returns null when no IPv4/CIDR token is present', () => {
+    expect(parseIpAndCidr('Berechne Network ID')).toBeNull();
+    expect(parseIpAndCidr('')).toBeNull();
+  });
+
+  it('returns null when an octet is out of range', () => {
+    expect(parseIpAndCidr('999.1.1.1/24')).toBeNull();
+    expect(parseIpAndCidr('10.256.0.1/24')).toBeNull();
+  });
+
+  it('returns null when the CIDR is out of range', () => {
+    expect(parseIpAndCidr('10.0.0.1/33')).toBeNull();
+    expect(parseIpAndCidr('10.0.0.1/-1')).toBeNull();
+    expect(parseIpAndCidr('10.0.0.1/abc')).toBeNull();
+  });
+
+  it('does not greedily consume extra digits past the CIDR', () => {
+    // The lookahead `(?!\d)` prevents matching /245 when the slash is
+    // followed by more digits; we want the two-digit prefix only.
+    const result = parseIpAndCidr('10.0.0.1/24foo');
+    expect(result?.cidr).toBe(24);
+  });
+
+  it('returns null for non-string input', () => {
+    // @ts-expect-error - exercising runtime guard
+    expect(parseIpAndCidr(undefined)).toBeNull();
+    // @ts-expect-error - exercising runtime guard
+    expect(parseIpAndCidr(null)).toBeNull();
+  });
+});
+
+describe('countCidrFromMask', () => {
+  it('counts 1-bits across dotted-decimal masks', () => {
+    expect(countCidrFromMask('255.255.255.0')).toBe(24);
+    expect(countCidrFromMask('255.255.0.0')).toBe(16);
+    expect(countCidrFromMask('255.255.255.128')).toBe(25);
+    expect(countCidrFromMask('255.255.255.252')).toBe(30);
+    expect(countCidrFromMask('128.0.0.0')).toBe(1);
+  });
+
+  it('returns 0 for /0 mask', () => {
+    expect(countCidrFromMask('0.0.0.0')).toBe(0);
+  });
+
+  it('returns null for malformed input', () => {
+    expect(countCidrFromMask('')).toBeNull();
+    expect(countCidrFromMask('not-a-mask')).toBeNull();
+    expect(countCidrFromMask('255.255.255')).toBeNull();
+    expect(countCidrFromMask('255.255.300.0')).toBeNull();
+    expect(countCidrFromMask('-1.0.0.0')).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Component rendering
+// ===========================================================================
+
+describe('SubnettingVisualizer — rendering', () => {
+  it('renders a clearly-labelled section with the subnetting data', () => {
+    const question = makeSubnettingQuestion();
+    render(<SubnettingVisualizer question={question} />);
+
+    expect(screen.getByTestId('subnetting-visualizer')).toBeInTheDocument();
+    expect(screen.getByText('Visuelle Aufschlüsselung')).toBeInTheDocument();
+  });
+
+  it('shows the IP and CIDR parsed from questionText', () => {
+    const question = makeSubnettingQuestion();
+    render(<SubnettingVisualizer question={question} />);
+
+    expect(screen.getByTestId('viz-given-ip')).toHaveTextContent('10.5.3.4');
+    expect(screen.getByTestId('viz-cidr')).toHaveTextContent('/24');
+  });
+
+  it('falls back to CIDR derived from the subnet mask when no IP/CIDR is in the text', () => {
+    const question = makeSubnettingQuestion({
+      questionText: 'Berechne die Subnetz-Werte für diese Aufgabe.',
+    });
+    render(<SubnettingVisualizer question={question} />);
+
+    // No IP parsed → IP node should not appear.
+    expect(screen.queryByTestId('viz-given-ip')).toBeNull();
+    // But CIDR is still recoverable from the mask.
+    expect(screen.getByTestId('viz-cidr')).toHaveTextContent('/24');
+  });
+
+  it('shows the expected subnet mask, network, broadcast, host range, and usable hosts', () => {
+    const question = makeSubnettingQuestion();
+    render(<SubnettingVisualizer question={question} />);
+
+    expect(screen.getByTestId('viz-mask')).toHaveTextContent('255.255.255.0');
+    expect(screen.getByTestId('viz-network-id')).toHaveTextContent('10.5.3.0');
+    expect(screen.getByTestId('viz-broadcast')).toHaveTextContent('10.5.3.255');
+    expect(screen.getByTestId('viz-host-min')).toHaveTextContent('10.5.3.1');
+    expect(screen.getByTestId('viz-host-max')).toHaveTextContent('10.5.3.254');
+    // German locale formatting
+    expect(screen.getByTestId('viz-usable-hosts')).toHaveTextContent('254');
+  });
+
+  it('renders two SVGs (bit bar + range bar) with descriptive aria-labels', () => {
+    const question = makeSubnettingQuestion();
+    render(<SubnettingVisualizer question={question} />);
+
+    const bitBar = screen.getByRole('img', {
+      name: /32-Bit-Aufteilung: 24 Netzwerk-Bits, 8 Host-Bits/,
+    });
+    expect(bitBar).toBeInTheDocument();
+
+    const rangeBar = screen.getByRole('img', {
+      name: /Adressbereich: 10\.5\.3\.0 \(Network\) bis 10\.5\.3\.255 \(Broadcast\)/,
+    });
+    expect(rangeBar).toBeInTheDocument();
+  });
+
+  it('shows the same detail values regardless of IP/CIDR parsing outcome', () => {
+    const withText = makeSubnettingQuestion();
+    const withoutText = makeSubnettingQuestion({
+      questionText: 'Komplett anderer Text ohne IP.',
+    });
+    const { rerender } = render(<SubnettingVisualizer question={withText} />);
+    const networkIdA = screen.getByTestId('viz-network-id').textContent;
+    const usableHostsA = screen.getByTestId('viz-usable-hosts').textContent;
+
+    rerender(<SubnettingVisualizer question={withoutText} />);
+    expect(screen.getByTestId('viz-network-id').textContent).toBe(networkIdA);
+    expect(screen.getByTestId('viz-usable-hosts').textContent).toBe(usableHostsA);
+  });
+});
+
+// ===========================================================================
+// Subnetting-only gating (handled by the parent in StudyCard.tsx).
+// The component itself still renders a usable visual for any subnetting-like
+// payload it receives, so we test the gating behaviour at the integration
+// level via the StudyCard test (see StudyCard.test.tsx).
+// ===========================================================================
+
+describe('SubnettingVisualizer — non-subnetting payloads still render visual fields', () => {
+  // The component is gated by the parent, so we don't expect it to refuse
+  // a non-subnetting module here. Instead we assert that it gracefully shows
+  // whatever values exist in `expectedAnswers` — degradation, not crash.
+  it('renders gracefully with an unexpected module id', () => {
+    const question = makeSubnettingQuestion({ module: 'something-else' });
+    render(<SubnettingVisualizer question={question} />);
+
+    expect(screen.getByTestId('viz-network-id')).toHaveTextContent('10.5.3.0');
+  });
+});
+
+// ===========================================================================
+// Detail row "Tone" sanity (catches regressions in the visible labels).
+// ===========================================================================
+
+describe('SubnettingVisualizer — German labels and accessibility', () => {
+  it('uses German section labels', () => {
+    render(<SubnettingVisualizer question={makeSubnettingQuestion()} />);
+
+    // Section labels
+    expect(screen.getByText('32-Bit-Aufteilung')).toBeInTheDocument();
+    expect(screen.getByText('Adressbereich im Subnetz')).toBeInTheDocument();
+
+    // Detail labels
+    const dl = screen.getByLabelText('Erwartete Subnetz-Werte');
+    expect(within(dl).getByText('Network ID')).toBeInTheDocument();
+    expect(within(dl).getByText('Broadcast')).toBeInTheDocument();
+    expect(within(dl).getByText('Subnetzmaske')).toBeInTheDocument();
+    expect(within(dl).getByText('Erster Host')).toBeInTheDocument();
+    expect(within(dl).getByText('Letzter Host')).toBeInTheDocument();
+    expect(within(dl).getByText('Nutzbare Hosts')).toBeInTheDocument();
+  });
+
+  it('marks the wrapper section with a meaningful aria-label', () => {
+    render(<SubnettingVisualizer question={makeSubnettingQuestion()} />);
+
+    const section = screen.getByLabelText('Subnetting Visualisierung');
+    expect(section.tagName.toLowerCase()).toBe('section');
+  });
+});

--- a/src/app/components/__tests__/SubnettingVisualizer.test.tsx
+++ b/src/app/components/__tests__/SubnettingVisualizer.test.tsx
@@ -214,6 +214,25 @@ describe('SubnettingVisualizer — rendering', () => {
     expect(rangeBar).toBeInTheDocument();
   });
 
+  it('uses exponentiation for /0 address counts instead of bit-shift overflow', () => {
+    const question = makeSubnettingQuestion({
+      questionText: 'Gegeben: IP-Adresse 0.0.0.0/0\nBerechne: ...',
+      expectedAnswers: {
+        networkId: '0.0.0.0',
+        broadcast: '255.255.255.255',
+        hostMin: '0.0.0.1',
+        hostMax: '255.255.255.254',
+        subnetMask: '0.0.0.0',
+        usableHosts: 4294967294,
+      },
+    });
+
+    render(<SubnettingVisualizer question={question} />);
+
+    expect(screen.getByText(/4\.294\.967\.296 Adressen/)).toBeInTheDocument();
+    expect(screen.getByText(/4\.294\.967\.294 nutzbar/)).toBeInTheDocument();
+  });
+
   it('shows the same detail values regardless of IP/CIDR parsing outcome', () => {
     const withText = makeSubnettingQuestion();
     const withoutText = makeSubnettingQuestion({

--- a/src/app/components/__tests__/SubnettingVisualizer.test.tsx
+++ b/src/app/components/__tests__/SubnettingVisualizer.test.tsx
@@ -39,6 +39,7 @@ vi.mock('framer-motion', () => ({
     ),
   },
   AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  useReducedMotion: () => false,
 }));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**Zusammenstellung von Kody**
<!-- kody-pr-summary:start -->
## What changed

This PR adds an **SVG-based subnetting visualizer** that appears inside the StudyCard for subnetting questions, helping learners connect abstract IP/CIDR inputs to the concrete bit layout and address range.

### New `SubnettingVisualizer.tsx`

A pure, self-contained component that renders three coordinated visual layers:

1. **Header** — given IP, `/CIDR`, and dotted subnet mask.
2. **32-bit split bar** — 32 cell-rectangles (one per bit) with network bits colored green, host bits in gray, octet dividers, octet range labels (`1–8`, `9–16`, …), and a dashed rose-colored vertical line marking the network/host boundary at the CIDR position.
3. **Address range bar** — a horizontal track with an **N** marker at the network ID (left), a **B** marker at the broadcast (right), the host range highlighted in the middle, and labels under each marker. A small chip in the corner shows the total address count vs. usable hosts.
4. **Detail grid** — a semantic `<dl>` listing Network ID, Broadcast, Subnetzmaske, Erster Host, Letzter Host, and Nutzbare Hosts with color-coded tones (emerald for network/usable hosts, rose for broadcast, amber for host endpoints, slate for the mask). Host counts use `de-DE` locale formatting.

### Parsing & fallback logic

Two pure helpers (exported for unit testing) drive the input:

- **`parseIpAndCidr(text)`** — anchored regex matches an IPv4 address with a `/CIDR` suffix from free-form question text (e.g. `Gegeben: IP-Adresse 10.5.3.4/24`). Validates that all octets are 0–255, the CIDR is 0–32, and uses a `(?!\\d)` lookahead so a token like `10.0.0.1/24foo` is parsed as `/24` rather than greedily consuming trailing digits. Returns `null` on any failure rather than throwing.
- **`countCidrFromMask(mask)`** — popcount-based fallback that recovers the CIDR prefix length from a dotted-decimal subnet mask if the question text doesn't contain an IP/CIDR token. Validates each octet (0–255) and returns `null` on malformed input.

The visualizer prefers the IP/CIDR parsed from text and falls back to mask-derived CIDR so the component degrades gracefully across generator text variants.

### Integration in `StudyCard.tsx`

The visualizer is conditionally rendered **between the question prompt and the answer inputs**, gated on `question.module === 'subnetting'`. It does not appear for any other module.

### Accessibility & responsiveness

- Wrapper `<section>` carries `aria-label="Subnetting Visualisierung"`.
- Both SVGs use `role="img"` with descriptive `aria-label`s summarizing the bit split and the address range.
- Detail grid is a real `<dl>`/`<dt>`/`<dd>` structure with `aria-label="Erwartete Subnetz-Werte"`.
- Icons are `aria-hidden="true"` (decorative).
- SVGs use `viewBox` + `preserveAspectRatio="xMidYMid meet"` with `w-full h-auto` for fluid container-width scaling.

### Animation

Uses `framer-motion`'s `motion.section` for a small fade/slide-in (opacity 0→1, y 6→0, 0.25s ease-out) so the visual feels integrated with the rest of the StudyCard's motion language.

### Tests

- **20 new unit tests** in `SubnettingVisualizer.test.tsx` covering `parseIpAndCidr` (whitespace tolerance, /17 and /32 boundaries, octet/CIDR range rejection, lookahead behavior, non-string input), `countCidrFromMask` (standard classful and VLSM masks, /0, malformed input), full component rendering, fallback to mask-derived CIDR, SVG a11y labels, German detail-row labels, and graceful handling of unexpected module IDs.
- **3 new integration tests** in `StudyCard.test.tsx` verifying that the visualizer renders for subnetting questions, that parsed IP/CIDR and expected answer values surface correctly, and that it does **not** render for non-subnetting questions.
- The existing `framer-motion` mock is extended with a `section` passthrough, and `lucide-react` mock gains `Network` and `Eye` icons used by the new component.

### Verification

- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- `npm test -- --silent` → 23 files / **294 tests** (up from 271, +23 new)
- `npm run build` ✅

---

## Summary

This PR refines the subnetting visualizer to prevent unintended answer leakage and fixes a calculation overflow bug:

- **Hides the visualizer until after submission or solution reveal.** Previously, the SVG visualizer rendered immediately when a subnetting question appeared, exposing answer values (network ID, broadcast, host range, usable host count) before the student had a chance to answer. The visualizer is now gated behind `checked || showSolution`, and tests were updated to assert this new behavior.
- **Fixes address-count overflow for `/0` subnets.** The total-address calculation used a left bit-shift (`1 << 32`), which overflows into a negative 32-bit integer. It now uses exponentiation (`2 ** 32`), correctly producing `4,294,967,296` for `/0`. A new test covers this case.
- **Minor cleanups:** removed a redundant length check in IP parsing, removed an unnecessary `Math.trunc` (the octet integer check that follows already enforces integer-ness), fixed a stray y-coordinate on the range-bar label, and added a trailing newline to two files.

---

## Summary

This PR hardens the subnetting visualizer's animation accessibility and adds a regression test for its reveal behavior.

### Changes

**Accessibility — `SubnettingVisualizer.tsx`**
- The visualizer's entrance animation (opacity + 6px vertical slide) now respects the user's `prefers-reduced-motion` setting. When the user has reduced-motion enabled, the component mounts instantly instead of animating, which avoids triggering vestibular discomfort.
- The decorative `Eye` icons in the two section headers are now marked `aria-hidden="true"` so screen readers don't announce them as meaningful content.

**Test mocking — both `StudyCard.test.tsx` and `SubnettingVisualizer.test.tsx`**
- The `framer-motion` mock now exports `useReducedMotion` (returning `false` by default) so the component under test can import it without crashing in jsdom.

**Regression coverage — `StudyCard.test.tsx`**
- New test locks in the behavior that the subnetting visualizer is rendered **after the user submits an answer** (`checked === true`), in addition to the existing `showSolution` branch. The test fills all six subnetting input fields, clicks "Antwort prüfen", and asserts that the visualizer appears with the correct IP, CIDR, and usable host count. This guards against a future refactor accidentally dropping `checked` from the reveal condition and silently leaking answer data before submission.
<!-- kody-pr-summary:end -->